### PR TITLE
[bugfix] Setting the player to the loading screen on create, not when…

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -136,7 +136,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         );
         var accessibilityControls = new AccessibilityControls(this); //keyboard support
         this.state.configLoaded = true;
-        this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
         this.renderSkin();
       }, this));
 
@@ -147,6 +146,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       }
 
       this.externalPluginSubscription();
+      this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
     },
 
     onAuthorizationFetched: function(event, authorization) {


### PR DESCRIPTION
… we retrieve the skin file. This prevents getting stuck on the loading screen if playbackReady is fired before we get the skin file loaded.
