### PR TITLE
Change the build sequence.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -10,7 +10,8 @@ var gulp = require('gulp'),
     gutil = require('gulp-util'),
     sourcemaps = require('gulp-sourcemaps'),
     uglify = require('gulp-uglify'),
-    shell = require('gulp-shell');
+    shell = require('gulp-shell'),
+    sequence = require('gulp-sequence');
 
 var path = {
   scripts: ['./js/components/*.js', './js/constants/*.js', './js/styles/*.js', './js/views/*.js', './js/*.js'],
@@ -18,7 +19,7 @@ var path = {
 };
 
 // Build All
-gulp.task('build', ['browserify', 'pretty', 'buildCss', 'insertVersion']);
+gulp.task('build', sequence(['browserify', 'pretty', 'buildCss'], 'insertVersion'));
 
 // Browserify JS
 gulp.task('browserify', function () {

--- a/package.json
+++ b/package.json
@@ -26,15 +26,16 @@
   "devDependencies": {
     "browserify": "11.0.1",
     "gulp": "3.8.11",
+    "gulp-sequence": "^0.4.1",
     "gulp-shell": "0.4.2",
     "gulp-sourcemaps": "1.5.2",
     "gulp-uglify": "1.1.0",
     "gulp-util": "3.0.6",
     "jest-cli": "0.4.18",
-    "react-tools":"*",
+    "react-tools": "*",
     "reactify": "1.1.1",
-    "vinyl-source-stream": "^1.0.0",
-    "vinyl-buffer": "^1.0.0"
+    "vinyl-buffer": "^1.0.0",
+    "vinyl-source-stream": "^1.0.0"
   },
   "author": "Ooyala",
   "contributors": [


### PR DESCRIPTION
This is a fix for the issue #207
`npm install` is required to install `gulp-sequence`.
(though gulp 4.0 will natively support for defining task dependencies in series or in parallel, which will make `gulp-sequence` unnecessary.)