### PR TITLE
upgrade jest to work with node v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "gulp-sourcemaps": "1.5.2",
     "gulp-uglify": "1.1.0",
     "gulp-util": "3.0.6",
-    "jest-cli": "0.4.18",
+    "jest-cli": "0.7.1",
     "react-tools":"*",
     "reactify": "1.1.1",
     "vinyl-source-stream": "^1.0.0",


### PR DESCRIPTION
@ksunika @chibzu @aldigun @rchalooyala 

We need to upgrade our local node to v4 to work w/ this update.

Latest node version is v4.2.2