### PR TITLE
[PBW-3127] control bar hiding logic moved to controller

### DIFF
--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -24,6 +24,10 @@ var ControlBar = React.createClass({
     }
   },
 
+  componentWillUnmount: function () {
+    this.props.controller.cancelTimer();
+  },
+
   handleControlBarMouseUp: function(evt) {
     if (evt.type == 'touchend' || !this.isMobile){
       evt.stopPropagation(); // W3C
@@ -32,6 +36,7 @@ var ControlBar = React.createClass({
       if (this.props.controller.state.volumeState.volumeSliderVisible){
         this.props.controller.hideVolumeSliderBar();
       }
+      this.props.controller.startHideControlBarTimer();
     }
   },
 
@@ -49,6 +54,7 @@ var ControlBar = React.createClass({
       //since mobile would fire both click and touched events,
       //we need to make sure only one actually does the work
       if (this.isMobile){
+        this.props.controller.startHideControlBarTimer();
         evt.stopPropagation(); // W3C
         evt.cancelBubble = true; // IE
         if (this.props.controller.state.volumeState.volumeSliderVisible){
@@ -65,12 +71,14 @@ var ControlBar = React.createClass({
   },
 
   handleVolumeBarTouchEnd: function(evt) {
+    this.props.controller.startHideControlBarTimer();
     //to prevent volume slider from hiding when clicking on volume slider
     evt.stopPropagation(); // W3C
     evt.cancelBubble = true; // IE
   },
 
   handleVolumeHeadTouchStart: function(evt) {
+    this.props.controller.startHideControlBarTimer();
     evt.preventDefault();
     evt.stopPropagation(); // W3C
     evt.cancelBubble = true; // IE
@@ -85,6 +93,7 @@ var ControlBar = React.createClass({
   },
 
   handleVolumeHeadMove: function(evt) {
+    this.props.controller.startHideControlBarTimer();
     evt.preventDefault();
     evt.stopPropagation(); // W3C
     evt.cancelBubble = true; // IE
@@ -107,6 +116,7 @@ var ControlBar = React.createClass({
   },
 
   handleVolumeHeadTouchEnd: function(evt) {
+    this.props.controller.startHideControlBarTimer();
     evt.stopPropagation(); // W3C
     evt.cancelBubble = true; // IE
     this.setNewVolume(evt);
@@ -443,7 +453,6 @@ var ControlBar = React.createClass({
 
 
   render: function() {
-    console.log("xenia in CB render this.props.controlBarVisible",this.props.controlBarVisible);
     // Liusha: Uncomment the following code to support "threshold scaling control bar implementation"
     // var controlBarHeight = Utils.getScaledControlBarHeight(this.props.controlBarWidth);
     // this.scaleControlBarItemsBasedOnControlBarSize(controlBarHeight);

--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -443,6 +443,7 @@ var ControlBar = React.createClass({
 
 
   render: function() {
+    console.log("xenia in CB render this.props.controlBarVisible",this.props.controlBarVisible);
     // Liusha: Uncomment the following code to support "threshold scaling control bar implementation"
     // var controlBarHeight = Utils.getScaledControlBarHeight(this.props.controlBarWidth);
     // this.scaleControlBarItemsBasedOnControlBarSize(controlBarHeight);

--- a/js/controller.js
+++ b/js/controller.js
@@ -782,19 +782,29 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.renderSkin();
     },
 
-    startHideControlBarTimer: function(){
-      console.log("xenia in startHideControlBarTimer");
-      if (this.state.timer !== null){
-        clearTimeout(this.state.timer);
-      }
-      var timer = setTimeout(function(){
+    startHideControlBarTimer: function() {
+      this.cancelTimer();
+      var timer = setTimeout(function() {
         if(this.state.controlBarVisible === true){
-          this.state.controlBarVisible = false;
+          this.hideControlBar();
         }
       }.bind(this), 3000);
       this.state.timer = timer;
-    }
+    },
 
+    showControlBar: function() {
+      this.state.controlBarVisible = true;
+    },
+
+    hideControlBar: function() {
+      this.state.controlBarVisible = false;
+    },
+
+    cancelTimer: function() {
+      if (this.state.timer !== null){
+        clearTimeout(this.state.timer);
+      }
+    }
   };
 
   return Html5Skin;

--- a/js/controller.js
+++ b/js/controller.js
@@ -73,6 +73,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       },
 
       "isMobile": false,
+      "controlBarVisible": true,
+      "timer": null,
       "errorCode": null
     };
 
@@ -778,7 +780,21 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     showVolumeSliderBar: function() {
       this.state.volumeState.volumeSliderVisible = true;
       this.renderSkin();
+    },
+
+    startHideControlBarTimer: function(){
+      console.log("xenia in startHideControlBarTimer");
+      if (this.state.timer !== null){
+        clearTimeout(this.state.timer);
+      }
+      var timer = setTimeout(function(){
+        if(this.state.controlBarVisible === true){
+          this.state.controlBarVisible = false;
+        }
+      }.bind(this), 3000);
+      this.state.timer = timer;
     }
+
   };
 
   return Html5Skin;

--- a/js/views/adScreen.js
+++ b/js/views/adScreen.js
@@ -31,14 +31,12 @@ var AdScreen = React.createClass({
 
     //for mobile or desktop fullscreen, hide control bar after 3 seconds
     if (this.isMobile || this.props.fullscreen){
-      this.startHideControlBarTimer();
+      this.props.controller.startHideControlBarTimer();
     }
   },
 
   componentWillUnmount: function () {
-    if (this.state.timer !== null) {
-      clearTimeout(this.state.timer);
-    }
+    this.props.controller.cancelTimer();
     window.removeEventListener('resize', this.handleResize);
     window.removeEventListener('webkitfullscreenchange', this.handleResize);
     window.removeEventListener('mozfullscreenchange', this.handleResize);
@@ -48,27 +46,24 @@ var AdScreen = React.createClass({
 
   componentWillUpdate: function(nextProps, nextState) {
     if(nextProps) {
-      if(!this.props.fullscreen && nextProps.fullscreen && this.state.playerState != CONSTANTS.STATE.PAUSE) {
-        this.startHideControlBarTimer();
-      }
-    }
-  },
-
-  startHideControlBarTimer: function(){
-    if (this.state.timer !== null) {
-      clearTimeout(this.state.timer);
-    }
-    var timer = setTimeout(function(){
-      if(this.state.controlBarVisible){
+      if (nextProps.controller.state.controlBarVisible == false && this.state.controlBarVisible == true) {
         this.hideControlBar();
       }
-    }.bind(this), 3000);
-    this.setState({timer: timer});
+
+      if(!this.props.fullscreen && nextProps.fullscreen && this.state.playerState != CONSTANTS.STATE.PAUSE) {
+        this.props.controller.startHideControlBarTimer();
+      }
+      if(this.props.fullscreen && !nextProps.fullscreen && this.isMobile) {
+        this.showControlBar();
+        this.props.controller.startHideControlBarTimer();
+      }
+    }
   },
 
   handleResize: function(e) {
     if (this.isMounted()) {
       this.setState({controlBarWidth: this.getDOMNode().clientWidth});
+      this.props.controller.startHideControlBarTimer();
     }
   },
 
@@ -99,18 +94,20 @@ var AdScreen = React.createClass({
 
   showControlBar: function() {
     this.setState({controlBarVisible: true});
+    this.props.controller.showControlBar();
     this.refs.AdScreen.getDOMNode().style.cursor="auto";
   },
 
   hideControlBar: function() {
     this.setState({controlBarVisible: false});
+    this.props.controller.hideControlBar();
     this.refs.AdScreen.getDOMNode().style.cursor="none";
   },
 
   handleTouchEnd: function(event) {
-    if (!this.state.controlBarVisible){
+    if (!this.state.controlBarVisible && this.props.skinConfig.adScreen.showControlBar){
       this.showControlBar();
-      this.startHideControlBarTimer();
+      this.props.controller.startHideControlBarTimer();
     }
     else {
       this.handlePlayerClicked(event);
@@ -125,7 +122,7 @@ var AdScreen = React.createClass({
     }
     else if(!this.isMobile && this.props.fullscreen) {
       this.showControlBar();
-      this.startHideControlBarTimer();
+      this.props.controller.startHideControlBarTimer();
     }
   },
 

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -35,22 +35,8 @@ var PlayingScreen = React.createClass({
     }
   },
 
-  // startHideControlBarTimer: function(){
-  //   if (this.state.timer !== null){
-  //     clearTimeout(this.state.timer);
-  //   }
-  //   var timer = setTimeout(function(){
-  //     if(this.state.controlBarVisible){
-  //       this.hideControlBar();
-  //     }
-  //   }.bind(this), 3000);
-  //   this.setState({timer: timer});
-  // },
-
   componentWillUnmount: function () {
-    // if (this.state.timer !== null){
-    //   clearTimeout(this.state.timer);
-    // }
+    this.props.controller.cancelTimer();
     window.removeEventListener('resize', this.handleResize);
     window.removeEventListener('webkitfullscreenchange', this.handleResize);
     window.removeEventListener('mozfullscreenchange', this.handleResize);
@@ -59,12 +45,16 @@ var PlayingScreen = React.createClass({
   },
 
   componentWillUpdate: function(nextProps, nextState) {
-    console.log("xenia in nextProps",nextProps.controller.state.controlBarVisible);
-    if (nextProps.controller.state.controlBarVisible == false && this.state.controlBarVisible == true) {
-      this.hideControlBar();
-    }
     if(nextProps) {
+      if (nextProps.controller.state.controlBarVisible == false && this.state.controlBarVisible == true) {
+        this.hideControlBar();
+      }
       if(!this.props.fullscreen && nextProps.fullscreen) {
+        this.props.controller.startHideControlBarTimer();
+      }
+      if(this.props.fullscreen && !nextProps.fullscreen && this.isMobile) {
+        this.setState({controlBarVisible: true});
+        this.props.controller.showControlBar();
         this.props.controller.startHideControlBarTimer();
       }
     }
@@ -73,6 +63,7 @@ var PlayingScreen = React.createClass({
   handleResize: function(e) {
     if (this.isMounted()) {
       this.setState({controlBarWidth: this.getDOMNode().clientWidth});
+      this.props.controller.startHideControlBarTimer();
     }
   },
 
@@ -111,27 +102,20 @@ var PlayingScreen = React.createClass({
   showControlBar: function(event) {
     if (!this.isMobile || event.type == 'touchend') {
       this.setState({controlBarVisible: true});
-      this.props.controller.state.controlBarVisible = true; //xenia change to controller method
+      this.props.controller.showControlBar();
       this.refs.PlayingScreen.getDOMNode().style.cursor="auto";
     }
   },
 
   hideControlBar: function(event) {
-    console.log("xenia in hideControlBar");
     if (!this.isMobile || !event) {
-      console.log("xenia in hideControlBar2");
       this.setState({controlBarVisible: false});
+      this.props.controller.hideControlBar();
       this.refs.PlayingScreen.getDOMNode().style.cursor="none";
     }
   },
 
   render: function() {
-    console.log("xenia in render, this.props.controller.state.controlBarVisible",this.props.controller.state.controlBarVisible);
-    console.log("xenia in render, this.state.controlBarVisible",this.state.controlBarVisible);
-    // if (this.props.controller.state.controlBarVisible === false) {
-    //   this.hideControlBar();
-    // }
-
     var upNext = null;
     if (this.props.controller.state.upNextInfo.showing && this.props.controller.state.upNextInfo.upNextData) {
       upNext = <UpNextPanel {...this.props} controlBarVisible={this.state.controlBarVisible} currentPlayhead={this.props.currentPlayhead}/>;

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -31,26 +31,26 @@ var PlayingScreen = React.createClass({
 
     //for mobile or desktop fullscreen, hide control bar after 3 seconds
     if (this.isMobile || this.props.fullscreen){
-      this.startHideControlBarTimer();
+      this.props.controller.startHideControlBarTimer();
     }
   },
 
-  startHideControlBarTimer: function(){
-    if (this.state.timer !== null){
-      clearTimeout(this.state.timer);
-    }
-    var timer = setTimeout(function(){
-      if(this.state.controlBarVisible){
-        this.hideControlBar();
-      }
-    }.bind(this), 3000);
-    this.setState({timer: timer});
-  },
+  // startHideControlBarTimer: function(){
+  //   if (this.state.timer !== null){
+  //     clearTimeout(this.state.timer);
+  //   }
+  //   var timer = setTimeout(function(){
+  //     if(this.state.controlBarVisible){
+  //       this.hideControlBar();
+  //     }
+  //   }.bind(this), 3000);
+  //   this.setState({timer: timer});
+  // },
 
   componentWillUnmount: function () {
-    if (this.state.timer !== null){
-      clearTimeout(this.state.timer);
-    }
+    // if (this.state.timer !== null){
+    //   clearTimeout(this.state.timer);
+    // }
     window.removeEventListener('resize', this.handleResize);
     window.removeEventListener('webkitfullscreenchange', this.handleResize);
     window.removeEventListener('mozfullscreenchange', this.handleResize);
@@ -59,9 +59,13 @@ var PlayingScreen = React.createClass({
   },
 
   componentWillUpdate: function(nextProps, nextState) {
+    console.log("xenia in nextProps",nextProps.controller.state.controlBarVisible);
+    if (nextProps.controller.state.controlBarVisible == false && this.state.controlBarVisible == true) {
+      this.hideControlBar();
+    }
     if(nextProps) {
       if(!this.props.fullscreen && nextProps.fullscreen) {
-        this.startHideControlBarTimer();
+        this.props.controller.startHideControlBarTimer();
       }
     }
   },
@@ -90,7 +94,7 @@ var PlayingScreen = React.createClass({
     }
     if (!this.state.controlBarVisible){
       this.showControlBar(event);
-      this.startHideControlBarTimer();
+      this.props.controller.startHideControlBarTimer();
     }
     else {
       this.props.controller.togglePlayPause();
@@ -100,25 +104,34 @@ var PlayingScreen = React.createClass({
   handlePlayerMouseMove: function() {
     if(!this.isMobile && this.props.fullscreen) {
       this.showControlBar();
-      this.startHideControlBarTimer();
+      this.props.controller.startHideControlBarTimer();
     }
   },
 
   showControlBar: function(event) {
     if (!this.isMobile || event.type == 'touchend') {
       this.setState({controlBarVisible: true});
+      this.props.controller.state.controlBarVisible = true; //xenia change to controller method
       this.refs.PlayingScreen.getDOMNode().style.cursor="auto";
     }
   },
 
   hideControlBar: function(event) {
+    console.log("xenia in hideControlBar");
     if (!this.isMobile || !event) {
+      console.log("xenia in hideControlBar2");
       this.setState({controlBarVisible: false});
       this.refs.PlayingScreen.getDOMNode().style.cursor="none";
     }
   },
 
   render: function() {
+    console.log("xenia in render, this.props.controller.state.controlBarVisible",this.props.controller.state.controlBarVisible);
+    console.log("xenia in render, this.state.controlBarVisible",this.state.controlBarVisible);
+    // if (this.props.controller.state.controlBarVisible === false) {
+    //   this.hideControlBar();
+    // }
+
     var upNext = null;
     if (this.props.controller.state.upNextInfo.showing && this.props.controller.state.upNextInfo.upNextData) {
       upNext = <UpNextPanel {...this.props} controlBarVisible={this.state.controlBarVisible} currentPlayhead={this.props.currentPlayhead}/>;


### PR DESCRIPTION
Updates control bar hiding logic for Playing and Ad screens:
- used in full screen desktop, full/normal screen Android, normal screen iOS
- timer is set/cancelled in controller
- if control bar items touched, timer restarts