### PR TITLE
[PBW-3979] Centering text of error message

### DIFF
--- a/scss/components/_error-screen.scss
+++ b/scss/components/_error-screen.scss
@@ -15,6 +15,7 @@
       font-family: 'Roboto', sans-serif;
       font-weight: bold;
       margin-bottom: 30px;
+      text-align: center;
     }
 
     .error-description {


### PR DESCRIPTION
In _error-screen.scss for .error-title adding text-align: center fixes
the issue.