### PR TITLE
[PBW-3857] Discovery tray in full screen is not scaling properly

### DIFF
--- a/scss/components/_discovery-screen.scss
+++ b/scss/components/_discovery-screen.scss
@@ -28,6 +28,7 @@
     height: 100%;
 
     .discovery-panel-title {
+      position: absolute;
       line-height: 1;
       font-weight: bold;
       font-size: $font-size-md-screen-title; //this.props.skinConfig.discoveryScreen.panelTitle.titleFont.fontSize
@@ -42,40 +43,36 @@
     }
     .discoveryToasterContainerStyle {
       background-color: transparent;
-      min-height: 54%;
-      height: 84%;
+      height: 320px;
       width: 100%;
       overflow: auto;
+      white-space: nowrap;
       margin: auto;
     }
 
     .flexcontainer {
       display: -webkit-flex;
       display: flex;
-      -webkit-flex-flow: row wrap;
-      flex-flow: row wrap;
+      -webkit-flex-flow: column wrap;
+      flex-flow: column wrap;
       overflow: hidden;
-      align-items: left;
+      align-items: center;
       -webkit-align-items: center;
       justify-content: center;
     }
 
     .discoveryImageWrapperStyle {
       position: relative;
-      height: 25%;
-      width: 25%;
-      min-height: 84px;
-      min-width: 150px;
-      margin-bottom: 2%;
-      margin-right: 8%;
-      margin-left: 8%;
+      height: 84px;
+      width: 150px;
+      margin: 24px;
       flex-shrink: 0;
     }
 
     img.imageStyle {
       //position: absolute;
-      width: 100%;
-      height: 100%;
+      width: 150px;
+      height: 84px;
       display: block;
     }
 

--- a/scss/components/_discovery-screen.scss
+++ b/scss/components/_discovery-screen.scss
@@ -28,7 +28,6 @@
     height: 100%;
 
     .discovery-panel-title {
-      position: absolute;
       line-height: 1;
       font-weight: bold;
       font-size: $font-size-md-screen-title; //this.props.skinConfig.discoveryScreen.panelTitle.titleFont.fontSize
@@ -47,33 +46,36 @@
       height: 84%;
       width: 100%;
       overflow: auto;
-      white-space: nowrap;
       margin: auto;
     }
 
     .flexcontainer {
       display: -webkit-flex;
       display: flex;
-      -webkit-flex-flow: column wrap;
-      flex-flow: column wrap;
+      -webkit-flex-flow: row wrap;
+      flex-flow: row wrap;
       overflow: hidden;
-      align-items: center;
+      align-items: left;
       -webkit-align-items: center;
       justify-content: center;
     }
 
     .discoveryImageWrapperStyle {
       position: relative;
-      height: 84px;
-      width: 150px;
-      margin: 24px;
+      height: 25%;
+      width: 25%;
+      min-height: 84px;
+      min-width: 150px;
+      margin-bottom: 2%;
+      margin-right: 8%;
+      margin-left: 8%;
       flex-shrink: 0;
     }
 
     img.imageStyle {
       //position: absolute;
-      width: 150px;
-      height: 84px;
+      width: 100%;
+      height: 100%;
       display: block;
     }
 


### PR DESCRIPTION
Makes the size of discovery screen elements dynamic rather than fixed,
so they will adjust to match the view. Using a min-height/min-width to
prevent too small of an image from occurring on tiny screens.