### PR TITLE
[PBW-4025] Close caption is showing on End screen

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -326,10 +326,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.state.pluginsClickElement.removeClass("showing");
         this.state.screenToShow = CONSTANTS.SCREEN.PLAYING_SCREEN;
         this.state.playerState = CONSTANTS.STATE.PLAYING;
-        if (Utils.isSafari()){
-          //Safari only can set cc when the video is playing, not before
-          this.setClosedCaptionsLanguage();
-        }
+        this.setClosedCaptionsLanguage();
         this.state.mainVideoElement.removeClass('blur');
         this.renderSkin();
       }
@@ -411,6 +408,9 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     onVcPlayed: function(event, source) {
+      var language = "";
+      var mode = 'disabled';
+      this.mb.publish(OO.EVENTS.SET_CLOSED_CAPTIONS_LANGUAGE, language, {"mode": mode});
       if (source == OO.VIDEO.MAIN) {
         this.state.mainVideoDuration = this.state.duration;
       }


### PR DESCRIPTION
Publishing event to end CC at end of play. The check for ‘Safari’ was
preventing CC on replay as a result of the ending event change.