### PR TITLE
[PBW-4108] Fixes Playhead icon not moving after seek.

### DIFF
--- a/js/components/scrubberBar.js
+++ b/js/components/scrubberBar.js
@@ -152,6 +152,7 @@ var ScrubberBar = React.createClass({
       currentPlayhead: newPlayheadTime,
       scrubbingPlayheadX: 0
     });
+    this.props.controller.endSeeking();
   },
 
   handleScrubberBarMouseDown: function(evt) {
@@ -202,7 +203,6 @@ var ScrubberBar = React.createClass({
 
         if (this.state.scrubbingPlayheadX && this.state.scrubbingPlayheadX != 0) {
           playheadPaddingStyle.left = this.state.scrubbingPlayheadX;
-          this.props.controller.endSeeking();
         } else {
           playheadPaddingStyle.left = ((parseFloat(this.props.currentPlayhead) /
             parseFloat(this.props.duration)) * this.scrubberBarWidth);

--- a/js/components/scrubberBar.js
+++ b/js/components/scrubberBar.js
@@ -149,7 +149,8 @@ var ScrubberBar = React.createClass({
       * this.props.duration;
     this.props.controller.seek(newPlayheadTime);
     this.setState({
-      currentPlayhead: newPlayheadTime
+      currentPlayhead: newPlayheadTime,
+      scrubbingPlayheadX: 0
     });
   },
 
@@ -198,11 +199,13 @@ var ScrubberBar = React.createClass({
     var playheadPaddingStyle = {};
 
     if (!this.state.transitionedDuringSeek) {
-        if (!this.props.seeking) {
+
+        if (this.state.scrubbingPlayheadX && this.state.scrubbingPlayheadX != 0) {
+          playheadPaddingStyle.left = this.state.scrubbingPlayheadX;
+          this.props.controller.endSeeking();
+        } else {
           playheadPaddingStyle.left = ((parseFloat(this.props.currentPlayhead) /
             parseFloat(this.props.duration)) * this.scrubberBarWidth);
-        } else if (this.state.scrubbingPlayheadX) {
-          playheadPaddingStyle.left = this.state.scrubbingPlayheadX;
         }
 
         playheadPaddingStyle.left = Math.max(


### PR DESCRIPTION
Flips of the order of the check to see if we are scrubbing (seeking) and if so move icon to scrubbed position. If not, we move the icon according the the currentPlayhead. Also sets the 'scrubbingPlayheadX' (the delta on scrubbing) to 0 at the end of handlePlayheadMouseUp so that it is not constantly trying to apply the value.