### PR TITLE
[PBW-4018] Pointer/timeline reseting after overlay

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -469,7 +469,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       OO.log("onAdsPlayed is called from event = " + event);
       this.state.screenToShow = CONSTANTS.SCREEN.PLAYING_SCREEN;
       this.state.duration = 0;
-      this.skin.updatePlayhead(0, 0, 0);
+      this.skin.updatePlayhead(this.skin.state.currentPlayhead, this.skin.state.duration, this.skin.state.buffered);
       this.state.isPlayingAd = false;
       this.state.pluginsElement.removeClass("showing");
       this.state.pluginsClickElement.removeClass("showing");


### PR DESCRIPTION
Playhead was intentionally being set to 0,0,0 at the end of ad play.
Have instead set the values (playhead, duration, buffered) to the
current states for each