### PR TITLE
[PBW-4172] Clicking scrubber pointer reseting video to start

### DIFF
--- a/js/components/scrubberBar.js
+++ b/js/components/scrubberBar.js
@@ -143,13 +143,9 @@ var ScrubberBar = React.createClass({
       this.getDOMNode().parentNode.removeEventListener("touchmove", this.handlePlayheadMouseMove);
       document.removeEventListener("touchend", this.handlePlayheadMouseUp, true);
     }
-    var newPlayheadTime =
-      (this.state.scrubbingPlayheadX /
-        (this.props.controlBarWidth - (2 * CONSTANTS.UI.DEFAULT_SCRUBBERBAR_LEFT_RIGHT_PADDING)))
-      * this.props.duration;
-    this.props.controller.seek(newPlayheadTime);
+    this.props.controller.seek(this.props.currentPlayhead);
     this.setState({
-      currentPlayhead: newPlayheadTime,
+      currentPlayhead: this.props.currentPlayhead,
       scrubbingPlayheadX: 0
     });
     this.props.controller.endSeeking();


### PR DESCRIPTION
Formular for scrubber pointer used a variable that was set to 0. Using
this.props.currentPlayhead instead.