### PR TITLE
[PBW-4018] FIx playhead duration on overlayAd end

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -476,8 +476,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     onAdsPlayed: function(event) {
       OO.log("onAdsPlayed is called from event = " + event);
       this.state.screenToShow = CONSTANTS.SCREEN.PLAYING_SCREEN;
-      this.state.duration = 0;
-      this.skin.updatePlayhead(this.skin.state.currentPlayhead, this.skin.state.duration, this.skin.state.buffered);
+      this.skin.updatePlayhead(this.skin.state.currentPlayhead, this.state.mainVideoDuration, this.skin.state.buffered);
       this.state.isPlayingAd = false;
       this.state.pluginsElement.removeClass("showing");
       this.state.pluginsClickElement.removeClass("showing");


### PR DESCRIPTION
OverlayAds were setting main video duration to 0 on end - visible in
pause as the scrubber moving to the end, and not easily seen during
playback because it was very quickly set back to normal, but it was
happening in both playback and pause. Change instead sets duration to
mainvideo duration at end of ad.