### PR TITLE
[PBW-4293] Switch back to 'click' event-but with fix for showing controls

### DIFF
--- a/js/views/adScreen.js
+++ b/js/views/adScreen.js
@@ -67,12 +67,17 @@ var AdScreen = React.createClass({
     event.cancelBubble = true; // IE
 
     this.props.controller.state.accessibilityControlsEnabled = true;
+    if ((event.type == 'click' || !this.isMobile) && !this.props.skinConfig.adScreen.showAdMarquee) {
+      this.props.controller.onAdsClicked(CONSTANTS.AD_CLICK_SOURCE.VIDEO_WINDOW);
+    }
   },
 
   handlePlayerClicked: function(event) {
-    if (event.type == 'touchend' || !this.isMobile) {
+    if (event.type == 'click' || !this.isMobile) {
       //since mobile would fire both click and touched events,
       //we need to make sure only one actually does the work
+      //Touchend fires inconsistently and depends on the user 'releasing'
+      //the touch whereas click has predictable results, so we use click.
 
       //since after exiting the full screen, iPhone pauses the video and places an overlay play button in the middle
       //of the screen (which we can't remove), clicking the screen would start the video.


### PR DESCRIPTION
Switching back to using ‘click’ as it will fire consistently while
‘touchend’ will only fire when/if the user releases the touch, and
might not still send an event to the controller. But keeping the fix to
keep the control bar visible in pause.