### PR TITLE
Pbw 4293

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -134,7 +134,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.mb.subscribe(OO.EVENTS.CLOSED_CAPTION_CUE_CHANGED, "customerUi", _.bind(this.onClosedCaptionCueChanged, this));
         this.mb.subscribe(OO.EVENTS.VOLUME_CHANGED, "customerUi", _.bind(this.onVolumeChanged, this));
         this.mb.subscribe(OO.EVENTS.VC_VIDEO_ELEMENT_IN_FOCUS, "customerUi", _.bind(this.onVideoElementFocus, this));
-        this.mb.subscribe(OO.EVENTS.REPLAY, "customerUi", _.bind(this.onReplay, this));
 
         // ad events
         if (!Utils.isIPhone()) {
@@ -277,7 +276,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     onContentTreeFetched: function (event, contentTree) {
-      this.resetUpNextInfo(true);
+      this.resetUpNextInfo();
       this.state.contentTree = contentTree;
       this.state.playerState = CONSTANTS.STATE.START;
       this.renderSkin({"contentTree": contentTree});
@@ -287,10 +286,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.state.volumeState.volume = newVolume;
     },
 
-    resetUpNextInfo: function (purge) {
-      if (purge) {
-        this.state.upNextInfo.upNextData = null;
-      }
+    resetUpNextInfo: function () {
+      this.state.upNextInfo.upNextData = null;
       this.state.upNextInfo.countDownFinished = false;
       this.state.upNextInfo.countDownCancelled = false;
     },
@@ -486,10 +483,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.state.buffering = false;
         this.renderSkin();
       }
-    },
-
-    onReplay: function(event) {
-      this.resetUpNextInfo(false);
     },
 
     /********************************************************************

--- a/js/views/adScreen.js
+++ b/js/views/adScreen.js
@@ -67,12 +67,17 @@ var AdScreen = React.createClass({
     event.cancelBubble = true; // IE
 
     this.props.controller.state.accessibilityControlsEnabled = true;
+    if ((event.type == 'click' || !this.isMobile) && !this.props.skinConfig.adScreen.showAdMarquee) {
+      this.props.controller.onAdsClicked(CONSTANTS.AD_CLICK_SOURCE.VIDEO_WINDOW);
+    }
   },
 
   handlePlayerClicked: function(event) {
-    if (event.type == 'touchend' || !this.isMobile) {
+    if (event.type == 'click' || !this.isMobile) {
       //since mobile would fire both click and touched events,
       //we need to make sure only one actually does the work
+      //Touchend fires inconsistently and depends on the user 'releasing'
+      //the touch whereas click has predictable results, so we use click.
 
       //since after exiting the full screen, iPhone pauses the video and places an overlay play button in the middle
       //of the screen (which we can't remove), clicking the screen would start the video.

--- a/js/views/adScreen.js
+++ b/js/views/adScreen.js
@@ -67,17 +67,12 @@ var AdScreen = React.createClass({
     event.cancelBubble = true; // IE
 
     this.props.controller.state.accessibilityControlsEnabled = true;
-    if ((event.type == 'click' || !this.isMobile) && !this.props.skinConfig.adScreen.showAdMarquee) {
-      this.props.controller.onAdsClicked(CONSTANTS.AD_CLICK_SOURCE.VIDEO_WINDOW);
-    }
   },
 
   handlePlayerClicked: function(event) {
-    if (event.type == 'click' || !this.isMobile) {
+    if (event.type == 'touchend' || !this.isMobile) {
       //since mobile would fire both click and touched events,
       //we need to make sure only one actually does the work
-      //Touchend fires inconsistently and depends on the user 'releasing'
-      //the touch whereas click has predictable results, so we use click.
 
       //since after exiting the full screen, iPhone pauses the video and places an overlay play button in the middle
       //of the screen (which we can't remove), clicking the screen would start the video.


### PR DESCRIPTION
Switching back to using ‘click’ as it will fire consistently while
‘touchend’ will only fire when/if the user releases the touch, and
might not still send an event to the controller. But keeping the fix to
keep the control bar visible in pause.