### PR TITLE
[PBW-4259] only show buffering spinner when buffering or right after …

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -406,6 +406,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
           // default
           this.state.screenToShow = CONSTANTS.SCREEN.PAUSE_SCREEN;
         }
+        if (Utils.isIPhone()){
+          //iPhone pause screen is the same as start screen
+          this.state.screenToShow = CONSTANTS.SCREEN.START_SCREEN;
+        }
         this.state.playerState = CONSTANTS.STATE.PAUSE;
         this.state.mainVideoElement.addClass('blur');
         this.renderSkin();
@@ -440,6 +444,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       } else {
         this.state.screenToShow = CONSTANTS.SCREEN.END_SCREEN;
         this.mb.publish(OO.EVENTS.END_SCREEN_SHOWN);
+      }
+      if (Utils.isIPhone()){
+        //iPhone end screen is the same as start screen, except for the replay button
+        this.state.screenToShow = CONSTANTS.SCREEN.START_SCREEN;
       }
       this.skin.updatePlayhead(this.state.duration, this.state.duration, this.state.duration);
       this.state.playerState = CONSTANTS.STATE.END;
@@ -670,10 +678,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.toggleFullscreen();
       }
 
-      // iPhone end screen is the same as start screen, except for the replay button
-      if (Utils.isIPhone() && (this.state.playerState == CONSTANTS.STATE.END || this.state.playerState == CONSTANTS.STATE.PAUSE)){
-        this.state.screenToShow = CONSTANTS.SCREEN.START_SCREEN;
-      }
       this.renderSkin();
     },
 

--- a/js/views/startScreen.js
+++ b/js/views/startScreen.js
@@ -143,7 +143,7 @@ var StartScreen = React.createClass({
           {this.props.skinConfig.startScreen.showDescription ? descriptionMetadata : ''}
         </div>
 
-        {this.state.playButtonClicked || this.props.controller.state.buffering ? <Spinner /> : actionIcon}
+        {(this.state.playButtonClicked && this.props.controller.state.playerState == CONSTANTS.STATE.START) || this.props.controller.state.buffering ? <Spinner /> : actionIcon}
       </div>
     );
   }


### PR DESCRIPTION
…the play button clicked on start screen.

Adds the condition that prevents buffering spinner to be shown when pausing the ads.

Also, since the new fullscreen logic prevents the onFullscreenChanged to be called for iPhone, moving the logic from there to onPaused and onPlayed.
