### PR TITLE
[PBW-4484] IMA adds shifting up

### DIFF
--- a/scss/components/_plugins.scss
+++ b/scss/components/_plugins.scss
@@ -5,6 +5,7 @@
   right: 0;
   bottom: $control-bar-height;
   position: absolute;
+  height: 100%;
   overflow: hidden;
   display: none;
 }


### PR DESCRIPTION
Style sheet is expressely setting the plugin container to the top. Can
either remove absolute position (and create unpredictable future
issues), or set the height of the plugin to fill its container (height:
100%).