### PR TITLE
[PBW-4384] No sample text if language chosen has no locality settings

### DIFF
--- a/js/components/closedCaptionPanel.js
+++ b/js/components/closedCaptionPanel.js
@@ -75,6 +75,7 @@ var CCPreviewPanel = React.createClass({
   render: function(){
     var closedCaptionPreviewTitle = Utils.getLocalizedString(this.props.language, CONSTANTS.SKIN_TEXT.CLOSED_CAPTION_PREVIEW, this.props.localizableStrings);
     var closedCaptionSampleText = Utils.getLocalizedString(this.props.closedCaptionOptions.language, CONSTANTS.SKIN_TEXT.SAMPLE_TEXT, this.props.localizableStrings);
+    if (!closedCaptionSampleText) closedCaptionSampleText = Utils.getLocalizedString('en', CONSTANTS.SKIN_TEXT.SAMPLE_TEXT, this.props.localizableStrings);
 
     var previewCaptionClassName = ClassNames({
       'preview-caption': true,


### PR DESCRIPTION
Added ‘en’ as a default for the sample text if the results are blank.