### PR TITLE
[PBW-4199] Overlay close button opening ad pages

### DIFF
--- a/js/components/adOverlay.js
+++ b/js/components/adOverlay.js
@@ -8,18 +8,12 @@ var React = require('react'),
 
 var AdOverlay = React.createClass({
   closeOverlay: function(event) {
-    event.stopPropagation();
-    event.cancelBubble = true;
     this.props.controller.closeNonlinearAd();
     this.props.controller.onSkipAdClicked();
   },
 
   handleOverlayClick: function(event) {
-    if ((event.type == 'touchend' || !this.props.controller.state.isMobile) && event.target.tagName != "BUTTON"){
-      event.stopPropagation(); // W3C
-      event.cancelBubble = true; // IE
       this.props.controller.onAdsClicked(CONSTANTS.AD_CLICK_SOURCE.OVERLAY);
-    }
   },
 
   overlayLoaded: function() {
@@ -41,13 +35,14 @@ var AdOverlay = React.createClass({
     });
 
     return (
-      <div className={adOverlayClass} onMouseUp={this.handleOverlayClick} onTouchEnd={this.handleOverlayClick}>
-        <img src={this.props.overlay} className="adOverlayImage" onLoad={this.overlayLoaded}></img>
-
+      <div className={adOverlayClass}>
+        <a onClick={this.handleOverlayClick}>
+          <img src={this.props.overlay} className="adOverlayImage" onLoad={this.overlayLoaded} />
+        </a>
         <CloseButton cssClass={closeButtonClass}
-                     closeAction={this.closeOverlay}
-                     fontStyleClass={this.props.skinConfig.icons.dismiss.fontStyleClass + " adOverlayCloseButtonIcon"}
-                     ref="adOverlayCloseButton" />
+          closeAction={this.closeOverlay}
+          fontStyleClass={this.props.skinConfig.icons.dismiss.fontStyleClass + " adOverlayCloseButtonIcon"}
+          ref="adOverlayCloseButton" />
       </div>
     );
   }

--- a/js/components/adOverlay.js
+++ b/js/components/adOverlay.js
@@ -7,13 +7,13 @@ var React = require('react'),
     CONSTANTS = require('../constants/constants');
 
 var AdOverlay = React.createClass({
-  closeOverlay: function(event) {
+  closeOverlay: function() {
     this.props.controller.closeNonlinearAd();
     this.props.controller.onSkipAdClicked();
   },
 
-  handleOverlayClick: function(event) {
-      this.props.controller.onAdsClicked(CONSTANTS.AD_CLICK_SOURCE.OVERLAY);
+  handleOverlayClick: function() {
+    this.props.controller.onAdsClicked(CONSTANTS.AD_CLICK_SOURCE.OVERLAY);
   },
 
   overlayLoaded: function() {

--- a/js/components/adOverlay.js
+++ b/js/components/adOverlay.js
@@ -15,7 +15,7 @@ var AdOverlay = React.createClass({
   },
 
   handleOverlayClick: function(event) {
-    if (event.type == 'touchend' || !this.props.controller.state.isMobile){
+    if ((event.type == 'touchend' || !this.props.controller.state.isMobile) && event.target.tagName != "BUTTON"){
       event.stopPropagation(); // W3C
       event.cancelBubble = true; // IE
       this.props.controller.onAdsClicked(CONSTANTS.AD_CLICK_SOURCE.OVERLAY);

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -113,9 +113,8 @@ var PlayingScreen = React.createClass({
 
       {this.props.controller.state.buffering ? <Spinner /> : ''}
 
-      <div className="default-screen"
-           onMouseUp={this.handlePlayerMouseUp}
-           onTouchEnd={this.handleTouchEnd}>
+      <div className="default-screen">
+        <div className="expand" onMouseUp={this.handlePlayerMouseUp} onTouchEnd={this.handleTouchEnd}></div>
 
         <AdOverlay {...this.props}
           overlay={this.props.controller.state.adOverlayUrl}

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -59,7 +59,7 @@ var PlayingScreen = React.createClass({
 
   handlePlayerMouseUp: function(event) {
     // pause or play the video if the skin is clicked on desktop
-    if (!this.isMobile) {
+    if (!this.isMobile && event.target.tagName != "BUTTON") {
       event.stopPropagation(); // W3C
       event.cancelBubble = true; // IE
 

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -59,7 +59,7 @@ var PlayingScreen = React.createClass({
 
   handlePlayerMouseUp: function(event) {
     // pause or play the video if the skin is clicked on desktop
-    if (!this.isMobile && event.target.tagName != "BUTTON") {
+    if (!this.isMobile) {
       event.stopPropagation(); // W3C
       event.cancelBubble = true; // IE
 

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -114,7 +114,7 @@ var PlayingScreen = React.createClass({
       {this.props.controller.state.buffering ? <Spinner /> : ''}
 
       <div className="default-screen">
-        <div className="expand" onMouseUp={this.handlePlayerMouseUp} onTouchEnd={this.handleTouchEnd}></div>
+        <div className="state-screen-selectable" onMouseUp={this.handlePlayerMouseUp} onTouchEnd={this.handleTouchEnd}></div>
 
         <AdOverlay {...this.props}
           overlay={this.props.controller.state.adOverlayUrl}

--- a/scss/components/_state-screen.scss
+++ b/scss/components/_state-screen.scss
@@ -29,7 +29,7 @@
   .state-screen-selectable {
     @extend .expand;
     text-decoration:none;
-    cursor: pointer;
+    cursor: default;
     //for IE
     background-color:white;
     opacity: 0;

--- a/tests/components/adOverlay-test.js
+++ b/tests/components/adOverlay-test.js
@@ -71,7 +71,8 @@ describe('AdOverlay', function () {
         skinConfig={mockSkinConfig}
       />);
 
-    TestUtils.Simulate.mouseUp(ReactDOM.findDOMNode(DOM));
+    var ad = TestUtils.findRenderedDOMComponentWithTag(DOM, 'a');
+    TestUtils.Simulate.click(ad);
     expect(clickSource).toBe(CONSTANTS.AD_CLICK_SOURCE.OVERLAY);
   });
 

--- a/tests/views/playingScreen-test.js
+++ b/tests/views/playingScreen-test.js
@@ -17,13 +17,13 @@ describe('PlayingScreen', function () {
         }
       },
       togglePlayPause: function(){clicked = true},
-      startHideControlBarTimer: function() {moved = true},
+      startHideControlBarTimer: function() {moved = true}
     };
 
     // Render pause screen into DOM
     var DOM = TestUtils.renderIntoDocument(<PlayingScreen  controller = {mockController} />);
 
-    var screen = TestUtils.findRenderedDOMComponentWithClass(DOM, 'default-screen');
+    var screen = TestUtils.findRenderedDOMComponentWithClass(DOM, 'state-screen-selectable');
     
     TestUtils.Simulate.mouseMove(screen);
     expect(moved).toBe(false);
@@ -49,7 +49,7 @@ describe('PlayingScreen', function () {
     // Render pause screen into DOM
     var DOM = TestUtils.renderIntoDocument(<PlayingScreen  controller = {mockController} />);
 
-    var screen = TestUtils.findRenderedDOMComponentWithClass(DOM, 'default-screen');
+    var screen = TestUtils.findRenderedDOMComponentWithClass(DOM, 'state-screen-selectable');
     TestUtils.Simulate.touchEnd(screen);
     expect(clicked).toBe(true);
   });


### PR DESCRIPTION
In the event listener handleOverlayClick() (adOverlay.js), adds another
condition to check if the click event target is not a button(close
button).
Furthermore in playingScreen.js within handlePlayerMouseUp() event
listener adds the same condition to check if the click was not
originated from the button(close button of overlay).