### PR TITLE
[PBW-4390] CC button staying on replay

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -276,6 +276,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     onEmbedCodeChanged: function(event, embedCode, options) {
       this.state.videoQualityOptions.availableBitrates = null;
       this.state.closedCaptionOptions.availableLanguages = null;
+      this.state.discoveryData = null;
 
       this.state.assetId = embedCode;
       $.extend(true, this.state.playerParam, options);

--- a/js/controller.js
+++ b/js/controller.js
@@ -275,6 +275,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
 
     onEmbedCodeChanged: function(event, embedCode, options) {
       this.state.videoQualityOptions.availableBitrates = null;
+      this.state.closedCaptionOptions.availableLanguages = null;
 
       this.state.assetId = embedCode;
       $.extend(true, this.state.playerParam, options);


### PR DESCRIPTION
Ensure that the available languages is null when setting a new video.
We cannot do this in ‘Played’ because we cannot be sure a prior video
that has CC was fully played before a new video is set, so nulling the
list on setting an embed code, much as is done with availableBitrates.