### PR TITLE
[PBW-4549] Buffering events raised on Safari before clicking play whe…

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -497,7 +497,11 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     onBuffering: function(event) {
-      this.state.buffering = true;
+      if (this.state.isInitialPlay == false && this.state.screenToShow == CONSTANTS.SCREEN.START_SCREEN) {
+        this.state.buffering = false;
+      } else {
+        this.state.buffering = true;
+      }
       this.renderSkin();
     },
 


### PR DESCRIPTION
…n preloading

in onBuffering if the initialPlay is false and the screen to show is
the start screen then we are setting the this.state.buffering to false
else it will set it to true. Testing with up next showed no need for an
added check in setEmbedCode.