### PR TITLE
[PBW-4542] We are unable to perform pause/play after closing overlay.

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -648,8 +648,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         left: "",
         right: "",
         bottom: "",
-        height: "",
-        width: "",
+        height: "0px",
+        width: "0px",
         transform: ""
       });
       this.renderSkin();


### PR DESCRIPTION
Even though overlay is being closed, the plugin object is still present
in front of the UI layer of the skin in order to fix a separate PBI
issue that was allowing users to skip past ads. This fix keeps the
object, but makes it take up no screen space, so that the UI can be
interacted with. This new fix is to avoid breaking PBI-1503.