### PR TITLE
[PBW-4638] Fix Bitmovin iPad Fullscreen bug

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -250,6 +250,13 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
 
     onVcVideoElementCreated: function(eventname, params) {
       var element = $("#" + params["domId"]);
+      var elementVideo = element.find("video");
+
+      //if video element is descendant
+      if (elementVideo.length) {
+        element = elementVideo;
+      }
+
       element.get(0).addEventListener("loadedmetadata", this.metaDataLoaded.bind(this));
 
       if (Utils.isIE10()) {


### PR DESCRIPTION
Bitmovin plugin adds wrapper elements around the main `video` element.

This was causing the main video element to be incorrectly set to a `div` instead of `video` and subsequently caused iOS iPad to fullscreen the `div` instead of `video`.