### PR TITLE
Debounce Resize

### DIFF
--- a/js/mixins/componentWidthMixin.js
+++ b/js/mixins/componentWidthMixin.js
@@ -1,4 +1,5 @@
-var ReactDOM = require('react-dom');
+var ReactDOM = require('react-dom'),
+    debounce = require('lodash.debounce');
 
 var ComponentWidthMixin = {
   getInitialState: function() {
@@ -8,7 +9,7 @@ var ComponentWidthMixin = {
   },
 
   componentDidMount: function() {
-    window.addEventListener('resize', this.onResize);
+    window.addEventListener('resize', debounce(this.onResize, 150));
     this.setState({
       componentWidth: ReactDOM.findDOMNode(this).getBoundingClientRect().width
     });

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "classnames": "*",
+    "lodash.debounce": "4.0.3",
     "react": "0.14.7",
     "react-dom": "0.14.7",
     "screenfull": "3.0.0"


### PR DESCRIPTION
* limit rate onResize func fires with resize listener
* the purpose of this update is to avoid costly calculations and component prop updates while window is resizing, see - 
https://lodash.com/docs#debounce