### PR TITLE
[PBW-4145] Ads controls are getting cut in fullscreen.

### DIFF
--- a/scss/base/_normalize.scss
+++ b/scss/base/_normalize.scss
@@ -9,7 +9,7 @@
 & {
   font-family: sans-serif; // 1
   -ms-text-size-adjust: 100%; // 2
-  -webkit-text-size-adjust: 100%; // 2
+  -webkit-text-size-adjust: none; // 2
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
Prevents ‘zoom-in’ issue with Android in landscape.