### PR TITLE
startScreen.js - removed default linear-gradient

### DIFF
--- a/js/views/startScreen.js
+++ b/js/views/startScreen.js
@@ -53,7 +53,7 @@ var StartScreen = React.createClass({
     };
     var posterImageUrl = this.props.skinConfig.startScreen.showPromo ? this.props.contentTree.promo_image : '';
     var posterStyle = {
-      backgroundImage: "linear-gradient(to bottom, rgba(0,0,0,0.8) 0%, rgba(0,0,0,0.3) 100%), url('" + posterImageUrl + "')"
+      backgroundImage: "url('" + posterImageUrl + "')"
     };
 
     //CSS class manipulation from config/skin.json


### PR DESCRIPTION
Updated the StartScreen posterStyle; removed the default linear-gradient. It would be better to declare this style property via the style sheet (not inline) as it is not easily removed without also removing the poster image.