### PR TITLE
rollback CC options screen to language tab only

### DIFF
--- a/js/components/closed-caption/closedCaptionPanel.js
+++ b/js/components/closed-caption/closedCaptionPanel.js
@@ -10,42 +10,14 @@
 var React = require('react'),
     OnOffSwitch = require('./onOffSwitch'),
     LanguageTab = require('./languageTab'),
-    ColorSelectionTab = require('./colorSelectionTab'),
-    CaptionOpacityTab = require('./captionOpacityTab'),
-    FontTypeTab = require('./fontTypeTab'),
-    FontSizeTab = require('./fontSizeTab'),
-    TextEnhancementsTab = require('./textEnhancementsTab'),
-    CCPreviewPanel = require('./ccPreviewPanel'),
-    Tabs = require('../tabs'),
-    Tab = Tabs.Panel;
+    CCPreviewPanel = require('./ccPreviewPanel');
 
 var ClosedCaptionPanel = React.createClass({
   render: function(){
     return (
         <div className="oo-content-panel oo-closed-captions-panel">
           <OnOffSwitch {...this.props} />
-
-          <Tabs className="captions-navbar">
-            <Tab title="Language">
-              <LanguageTab {...this.props} />
-            </Tab>
-            <Tab title="Color Selection">
-              <ColorSelectionTab />
-            </Tab>
-            <Tab title="Caption Opacity">
-              <CaptionOpacityTab />
-            </Tab>
-            <Tab title="Font Type">
-              <FontTypeTab />
-            </Tab>
-            <Tab title="Font Size">
-              <FontSizeTab />
-            </Tab>
-            <Tab title="Text Enhancements">
-              <TextEnhancementsTab />
-            </Tab>
-          </Tabs>
-
+          <LanguageTab {...this.props} />
           <CCPreviewPanel {...this.props} />
         </div>
     );

--- a/scss/responsive/_large.scss
+++ b/scss/responsive/_large.scss
@@ -61,7 +61,7 @@
     .oo-switch-container {
       height: 26px;
       width: 126px;
-      top: 40px;
+      top: 39px;
       left: 250px;
       .oo-switch-captions {
         font-size: $font-size-base * $large-multiple;

--- a/scss/responsive/_xsmall.scss
+++ b/scss/responsive/_xsmall.scss
@@ -55,7 +55,7 @@
     .oo-switch-container {
       height: 15px;
       width: 74px;
-      top: 22px;
+      top: 20px;
       left: 138px;
       .oo-switch-captions {
         font-size: $font-size-base * $xsmall-multiple;


### PR DESCRIPTION
This rollback is for May 2016 release only, latest updates are on feature branch `fcc-settings`