### PR TITLE
[PBW-4180] Fix seek when low bandwidth results in 'undefined'

### DIFF
--- a/js/components/scrubberBar.js
+++ b/js/components/scrubberBar.js
@@ -154,7 +154,7 @@ var ScrubberBar = React.createClass({
       offsetX = evt.targetTouches[0].pageX - evt.target.getBoundingClientRect().left;
     }
     else {
-      offsetX = evt.nativeEvent.offsetX;
+      offsetX = evt.nativeEvent.offsetX == undefined ? evt.nativeEvent.layerX : evt.nativeEvent.offsetX;
     }
 
     this.setState({


### PR DESCRIPTION
when seeked to a point in FF, the scrubber pointer starts from the beginning of the video. This is not seen in Chrome and Safari.
Finding that the point to which the scrubber bar has to move is undefined.

When scrubbing the video, the control first comes here to get the point to which the scrubber pointer has to move(scrubbingPlayheadX). The offsetX which is computed is not recognized in FF because -
**"Although mentioned in the W3 specification, the offsetx/offsety properties themselves are implemented inconsistently across browsers.
While supported in IE, Webkit browsers and Opera, they all function slightly different to the specifications requirements.
The properties aren't supported in Firefox at all - it appears to be a long-time bug that is yet to be resolved."**
This change puts in a condition that if it becomes undefined that the layerX(Mouse position relative to the closest positioned ancestor element) value will be taken and if the browser accepts offsetX(Mouse position relative to the target element), that value will be taken.