### PR TITLE
[PBW-5535] Thumbnails from previous asset are shown on the next asset without thumbnails

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -319,6 +319,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.state.videoQualityOptions.selectedBitrate = null;
       this.state.closedCaptionOptions.availableLanguages = null;
       this.state.discoveryData = null;
+      this.state.thumbnails = null;
       this.resetUpNextInfo(true);
 
       this.state.assetId = embedCode;


### PR DESCRIPTION
* Clear thumbnails data in onEmbedCodeChanged callback