### PR TITLE
[PBW-5633] [V4] Thumbnails sometimes jump to position that is not aligned with mouse pointing at their center

### DIFF
--- a/js/components/scrubberBar.js
+++ b/js/components/scrubberBar.js
@@ -272,14 +272,13 @@ var ScrubberBar = React.createClass({
         playheadClassName += " oo-playhead-hovering";
       }
       if (!thumbnailCarousel) {
-        thumbnailContainer =
+        thumbnailContainer = (
           <Thumbnail
            thumbnails={this.props.controller.state.thumbnails}
            hoverPosition={hoverPosition}
            duration={this.props.duration}
-           hoverTime={hoverTime > 0 ? hoverTime : 0}
-           thumbnailWidth={Thumbnail.getThumbnailWidth()}
-           scrubberBarWidth={this.state.scrubberBarWidth}/>
+           hoverTime={hoverTime > 0 ? hoverTime : 0} />
+        )
       }
     }
 

--- a/js/components/scrubberBar.js
+++ b/js/components/scrubberBar.js
@@ -278,6 +278,7 @@ var ScrubberBar = React.createClass({
            hoverPosition={hoverPosition}
            duration={this.props.duration}
            hoverTime={hoverTime > 0 ? hoverTime : 0}
+           thumbnailWidth={Thumbnail.getThumbnailWidth()}
            scrubberBarWidth={this.state.scrubberBarWidth}/>
       }
     }

--- a/js/components/thumbnail.js
+++ b/js/components/thumbnail.js
@@ -4,50 +4,21 @@
  * @module Thumbnail
  */
 var React = require('react'),
-    ReactDOM = require('react-dom'),
     Utils = require('./utils');
 
-var thumbnailWidth = 0;
-
 var Thumbnail = React.createClass({
-  statics: {
-    getThumbnailWidth: function() {
-      return thumbnailWidth;
-    }
-  },
-
-  getInitialState: function() {
-    return {
-      thumbnailWidth: 0
-    };
-  },
-
-  componentDidMount: function() {
-    var thmb = ReactDOM.findDOMNode(this.refs.thumbnail);
-    var width = thmb.clientWidth;
-    thumbnailWidth = width;
-    this.setState({thumbnailWidth: width});
-  },
-
   shouldComponentUpdate: function(nextProps) {
     return (nextProps.hoverPosition != this.props.hoverPosition);
   },
 
   render: function() {
     var thumbnail = Utils.findThumbnail(this.props.thumbnails, this.props.hoverTime, this.props.duration);
-    var thumbnailStyle = {};
-    var defaultThumbnailWidth = this.state.thumbnailWidth > 0 ? this.state.thumbnailWidth : this.props.thumbnailWidth;
-    var hoverPosition = 0;
-
-    if (this.props.hoverPosition - defaultThumbnailWidth/2 >= 0 && this.props.hoverPosition + defaultThumbnailWidth/2 < this.props.scrubberBarWidth) {
-      hoverPosition = this.props.hoverPosition - defaultThumbnailWidth/2;
-    }
-    else if (this.props.hoverPosition + defaultThumbnailWidth/2 > this.props.scrubberBarWidth){
-      hoverPosition = this.props.scrubberBarWidth - defaultThumbnailWidth;
-    }
-    thumbnailStyle.left = hoverPosition;
-    thumbnailStyle.backgroundImage = "url("+thumbnail.url+")";
     var time = isFinite(parseInt(this.props.hoverTime)) ? Utils.formatSeconds(parseInt(this.props.hoverTime)) : null;
+
+    var thumbnailStyle = {};
+    thumbnailStyle.left = this.props.hoverPosition;
+    thumbnailStyle.backgroundImage = "url("+thumbnail.url+")";
+
     return (
       <div className="oo-scrubber-thumbnail-container">
         <div className="oo-thumbnail" ref="thumbnail" style={thumbnailStyle}>
@@ -62,8 +33,7 @@ Thumbnail.defaultProps = {
   thumbnails: {},
   hoverPosition: 0,
   duration: 0,
-  hoverTime: 0,
-  scrubberBarWidth: 0
+  hoverTime: 0
 };
 
 module.exports = Thumbnail;

--- a/js/components/thumbnail.js
+++ b/js/components/thumbnail.js
@@ -7,7 +7,15 @@ var React = require('react'),
     ReactDOM = require('react-dom'),
     Utils = require('./utils');
 
+var thumbnailWidth = 0;
+
 var Thumbnail = React.createClass({
+  statics: {
+    getThumbnailWidth: function() {
+      return thumbnailWidth;
+    }
+  },
+
   getInitialState: function() {
     return {
       thumbnailWidth: 0
@@ -15,7 +23,10 @@ var Thumbnail = React.createClass({
   },
 
   componentDidMount: function() {
-    this.setState({thumbnailWidth: ReactDOM.findDOMNode(this.refs.thumbnail).clientWidth});
+    var thmb = ReactDOM.findDOMNode(this.refs.thumbnail);
+    var width = thmb.clientWidth;
+    thumbnailWidth = width;
+    this.setState({thumbnailWidth: width});
   },
 
   shouldComponentUpdate: function(nextProps) {
@@ -25,7 +36,7 @@ var Thumbnail = React.createClass({
   render: function() {
     var thumbnail = Utils.findThumbnail(this.props.thumbnails, this.props.hoverTime, this.props.duration);
     var thumbnailStyle = {};
-    var defaultThumbnailWidth = this.state.thumbnailWidth;
+    var defaultThumbnailWidth = this.state.thumbnailWidth > 0 ? this.state.thumbnailWidth : this.props.thumbnailWidth;
     var hoverPosition = 0;
 
     if (this.props.hoverPosition - defaultThumbnailWidth/2 >= 0 && this.props.hoverPosition + defaultThumbnailWidth/2 < this.props.scrubberBarWidth) {

--- a/scss/components/_thumbnail.scss
+++ b/scss/components/_thumbnail.scss
@@ -54,6 +54,7 @@
   background-repeat: no-repeat;
   background-size: cover;
   background-position: 50% 50%;
+  @include vendor-prefixes(transform, translateX(-50%));
 }
 
 .oo-thumbnail-time {


### PR DESCRIPTION
If mouse is moved slowly, Thumbnail object may go away and a new one will be created.  This object doesn't *know* thumbnail width, so it is zero during initial rendering, which results in wrong placing.  Solution is to save last thumbnail width and pass it as a parameter to next Thumbnail object.  Store this value in Thubmnail static method.