### PR TITLE
[PBW-5876] - Player will now display muted icon when initialVolume is set to 0

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -376,8 +376,14 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.renderSkin({"contentTree": contentTree});
     },
 
-    onVolumeChanged: function (event, newVolume){
+    onVolumeChanged: function (event, newVolume) {
+      if (newVolume == 0) {
+        this.state.volumeState.muted = true;
+      } else {
+        this.state.volumeState.muted = false;
+      }
       this.state.volumeState.volume = newVolume;
+      this.renderSkin();
     },
 
     resetUpNextInfo: function (purge) {
@@ -1082,16 +1088,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.mb.publish(OO.EVENTS.LIVE_BUTTON_CLICKED);
     },
 
-    setVolume: function(volume){
-      if(volume == 0) {
-        this.state.volumeState.muted = true;
-      }
-      else {
-        this.state.volumeState.muted = false;
-      }
-      this.state.volumeState.volume = volume;
+    setVolume: function(volume) {
       this.mb.publish(OO.EVENTS.CHANGE_VOLUME, volume);
-      this.renderSkin();
     },
 
     handleMuteClick: function() {


### PR DESCRIPTION
Eventually, I think it would be better to mimic the behavior of the HTML5 video API in which `muted` and `volume` properties are handled separately. This would allow the user to set an initial volume even if the player starts out muted.

For the scope of this ticket, I think the changes I made should be sufficient though.