### PR TITLE
[PBW-5876] - Player will now display muted icon when initialVolume is set to 0

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -393,8 +393,15 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.renderSkin({"contentTree": this.state.contentTree});
     },
 
-    onVolumeChanged: function (event, newVolume){
-      this.state.volumeState.volume = newVolume;
+    onVolumeChanged: function (event, newVolume) {
+      if (newVolume <= 0) {
+        this.state.volumeState.muted = true;
+        this.state.volumeState.volume = 0;
+      } else {
+        this.state.volumeState.muted = false;
+        this.state.volumeState.volume = newVolume;
+      }
+      this.renderSkin();
     },
 
     resetUpNextInfo: function (purge) {
@@ -1114,15 +1121,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     setVolume: function(volume){
-      if(volume == 0) {
-        this.state.volumeState.muted = true;
-      }
-      else {
-        this.state.volumeState.muted = false;
-      }
-      this.state.volumeState.volume = volume;
       this.mb.publish(OO.EVENTS.CHANGE_VOLUME, volume);
-      this.renderSkin();
     },
 
     handleMuteClick: function() {


### PR DESCRIPTION
Redid the pull request because I had the wrong branch. Also added Peter's suggested changes.

Original comment:

Eventually, I think it would be better to mimic the behavior of the HTML5 video API in which `muted `and `volume` properties are handled separately. This would allow the user to set an initial volume even if the player starts out muted.

For the scope of this ticket, I think the changes I made should be sufficient though.