### PR TITLE
[PBW-5864] Restoring main video's closed caption settings after ad plays

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -73,6 +73,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         "skipAdButtonEnabled": false
       },
 
+      "closedCaptionsInfoCache": {},
       "closedCaptionOptions": {
         "enabled": null,
         "language": null,
@@ -781,6 +782,9 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
 
     onVideoElementFocus: function(event, source) {
       this.focusedElement = source;
+      // Make sure that the skin uses the captions that correspond
+      // to the newly focused video element
+      this.setClosedCaptionsInfo(source);
       if (source == OO.VIDEO.MAIN) {
         this.state.pluginsElement.removeClass("oo-showing");
         this.state.pluginsClickElement.removeClass("oo-showing");
@@ -833,11 +837,11 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       }
     },
 
-    onClosedCaptionsInfoAvailable: function(event, languages) {
-      this.state.closedCaptionOptions.availableLanguages = languages;
-      if (this.state.closedCaptionOptions.enabled){
-        this.setClosedCaptionsLanguage();
-      }
+    onClosedCaptionsInfoAvailable: function(event, info) {
+      // Store info in cache in order to be able to restore it
+      // if this video element looses and then regains focus (like when an ad plays)
+      this.state.closedCaptionsInfoCache[info.videoId] = info;
+      this.setClosedCaptionsInfo(info.videoId);
     },
 
     onClosedCaptionCueChanged: function(event, data) {
@@ -1259,6 +1263,18 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         "id": selectedContentData.id
       };
       this.mb.publish(OO.EVENTS.SET_TARGET_BITRATE, selectedContentData.id);
+    },
+
+    setClosedCaptionsInfo: function(videoId) {
+      var closedCaptionsInfo = this.state.closedCaptionsInfoCache[videoId];
+      if (!closedCaptionsInfo) {
+        return;
+      }
+      // Load the CC info for the video with the given id onto the state
+      this.state.closedCaptionOptions.availableLanguages = closedCaptionsInfo;
+      if (this.state.closedCaptionOptions.enabled) {
+        this.setClosedCaptionsLanguage();
+      }
     },
 
     setClosedCaptionsLanguage: function(){

--- a/js/controller.js
+++ b/js/controller.js
@@ -337,6 +337,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.state.videoQualityOptions.availableBitrates = null;
       this.state.videoQualityOptions.selectedBitrate = null;
       this.state.closedCaptionOptions.availableLanguages = null;
+      this.state.closedCaptionsInfoCache = {};
       this.state.discoveryData = null;
       this.state.thumbnails = null;
       this.resetUpNextInfo(true);
@@ -363,6 +364,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     onAssetChanged: function (event, asset) {
       this.state.videoQualityOptions.availableBitrates = null;
       this.state.closedCaptionOptions.availableLanguages = null;
+      this.state.closedCaptionsInfoCache = {};
       this.state.discoveryData = null;
       this.subscribeBasicPlaybackEvents();
 

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -63,6 +63,7 @@ OO = {
         queuedPlayheadUpdate: true,
         currentAdsInfo: {},
         videoQualityOptions: {},
+        closedCaptionsInfoCache: {},
         closedCaptionOptions: {
           enabled: null,
           language: null,
@@ -187,6 +188,7 @@ OO = {
       closePopovers: function() {},
       setVolume: function(a) {},
       toggleVideoQualityPopOver: function(a) {},
+      setClosedCaptionsInfo: function() {},
       setClosedCaptionsLanguage: function() {},
       displayMoreOptionsScreen: function(a) {},
       closeMoreOptionsScreen: function() {},


### PR DESCRIPTION
This is the flow that was causing the issue:

1. On Firefox video preloading is enabled, so bitmovin plugin initializes on page load and fires `CAPTIONS_FOUND_ON_PLAYING`.
2. The `video controller` handles this event and then fires `CLOSED_CAPTIONS_INFO_AVAILABLE`.
3. The skin handles this event and uses its info to populate the CC menu.
4. When the video is played, the preroll video is loaded and bitmovin again fires `CAPTIONS_FOUND_ON_PLAYING`, this time with empty captions.
5. The `video controller` again fires `CLOSED_CAPTIONS_INFO_AVAILABLE`, which causes the skin to clear the captions that it had for the main video.
6. When the main video regains focus, the skin is stuck with the captions from the ad (which are empty in this case). 

It's also possible that this issue can occur after a mid-roll ad if the ad itself has subtitles. It seems that technically the bitmovin plugin could fire a `CAPTIONS_FOUND_ON_PLAYING` during mid-roll initialization and cause the skin to clear its closed captions data. I wasn't able to reproduce this locally though.

The solution I implemented was to have the skin keep track of CC info for all of the different video id's that have been active. When the `VC_VIDEO_ELEMENT_IN_FOCUS` event is received by the skin, it now makes sure that it has loaded the captions that match the currently active video.

