### PR TITLE
[PBW-5843] - Allowing clicks to pass through pause icon on ad screen

### DIFF
--- a/scss/components/_ad-screen.scss
+++ b/scss/components/_ad-screen.scss
@@ -15,6 +15,7 @@
   .oo-action-icon-pause.oo-animate-pause {
     z-index: $zindex-action-icon-pause-animate;
     cursor: default;
+    pointer-events: none; // Allow click to pass through
   }
 }
 


### PR DESCRIPTION
**Edit: I'm going to include another fix, please don't merge yet.**

So the fix is basically just allowing clicks to pass through the pause icon which blocks the video element even when it fades out.  This fix will not work on IE10 or lower, but considering [the list of supported browsers](http://support.ooyala.com/developers/documentation/concepts/pbv4_environments.html) I think this should be ok.