### PR TITLE
[PBW-5306] fix playhead position for pre and mid roll ads

### DIFF
--- a/js/components/scrubberBar.js
+++ b/js/components/scrubberBar.js
@@ -196,7 +196,7 @@ var ScrubberBar = React.createClass({
       backgroundColor: this.props.skinConfig.controlBar.scrubberBar.backgroundColor
     };
     var bufferedIndicatorStyle = {
-      width: (parseFloat(this.props.buffered) / parseFloat(this.props.duration)) * 100 + "%",
+      width: Math.min((parseFloat(this.props.buffered) / parseFloat(this.props.duration)) * 100, 100) + "%",
       backgroundColor: this.props.skinConfig.controlBar.scrubberBar.bufferedColor
     };
     var playedIndicatorStyle = {

--- a/js/controller.js
+++ b/js/controller.js
@@ -64,6 +64,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       "pluginsElement": null,
       "pluginsClickElement": null,
       "buffering": false,
+      "mainVideoBuffered": null,
       "mainVideoPlayhead": null,
       "focusedElement": null,
 
@@ -416,13 +417,16 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     onPlayheadTimeChanged: function(event, currentPlayhead, duration, buffered, startEnd, videoId) {
-      if (videoId == "main") {
+      if (videoId == OO.VIDEO.MAIN) {
         this.state.mainVideoPlayhead = currentPlayhead;
+        this.state.mainVideoDuration = duration;
+        this.state.mainVideoBuffered = buffered;
       }
       else if (videoId == OO.VIDEO.ADS) {
         //adVideoDuration is only used in adPanel ad marquee
         this.state.adVideoDuration = duration;
       }
+      this.state.duration = duration;
 
       // lower skin z-index if Chrome auto-pauses flash content
       if(!this.state.autoPauseDisabled && Utils.isChrome() && this.state.mainVideoMediaType != CONSTANTS.MEDIA_TYPE.HTML5) {
@@ -437,7 +441,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
 
       // The code inside if statement is only for up next, however, up next does not apply to Ad screen.
       // So we only need to update the playhead for ad screen.
-      this.state.duration = duration;
       if (this.state.screenToShow !== CONSTANTS.SCREEN.AD_SCREEN ) {
         if (this.skin.props.skinConfig.upNext.showUpNext) {
           if (!(Utils.isIPhone() || (Utils.isIos() && this.state.fullscreen))){//no UpNext for iPhone or fullscreen iPad
@@ -661,7 +664,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     onAdsPlayed: function(event) {
       OO.log("onAdsPlayed is called from event = " + event);
       this.state.screenToShow = CONSTANTS.SCREEN.PLAYING_SCREEN;
-      this.skin.updatePlayhead(this.skin.state.currentPlayhead, this.state.mainVideoDuration, this.skin.state.buffered);
+      this.skin.updatePlayhead(this.state.mainVideoPlayhead, this.state.mainVideoDuration, this.state.mainVideoBuffered);
       this.state.isPlayingAd = false;
       this.state.pluginsElement.removeClass("oo-showing");
       this.state.pluginsClickElement.removeClass("oo-showing");
@@ -736,6 +739,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     onSkipAdClicked: function(event) {
       this.state.isSkipAdClicked = true;
       OO.log("onSkipAdClicked is called");
+      this.skin.updatePlayhead(this.state.mainVideoPlayhead, this.state.mainVideoDuration, this.state.mainVideoBuffered);
       this.state.currentAdsInfo.skipAdButtonEnabled = false;
       this.mb.publish(OO.EVENTS.SKIP_AD);
       this.renderSkin();


### PR DESCRIPTION
1.) Afer ad plays or skip button is clicked, ensure playhead is updated with main video playhead, duration, buffer values
2.) Ensure buffer indicator does not exceed 100% of scrubber bar