### PR TITLE
[PBW-5843] Fixed adPanel's z-index when Pulse plugin is active

### DIFF
--- a/js/components/adPanel.js
+++ b/js/components/adPanel.js
@@ -133,6 +133,7 @@ var AdPanel = React.createClass({
     return (
       <div className="oo-ad-screen-panel">
         {spinner}
+        <div className="oo-ad-screen-panel-click-layer"></div>
         <div className="oo-ad-top-bar" ref="adTopBar" onClick={this.handleAdTopBarClick} onTouchEnd={this.handleAdTopBarClick}>
           {adTopBarItems}
         </div>

--- a/scss/base/_variables.scss
+++ b/scss/base/_variables.scss
@@ -123,6 +123,7 @@ $zindex-action-icon-pause-hidden:         11990 !default;
 $zindex-player-skin-plugins:              12000 !default;
 $zindex-start-screen:                     12005 !default;
 $zindex-player-skin-plugins-click-layer:  12005 !default;
+$zindex-ad-screen-panel-click-layer:      12005 !default;
 $zindex-control-bar:                      12500 !default;
 $zindex-scrubber-bar:                     12600 !default;
 $zindex-action-icon-pause-animate:        12600 !default;

--- a/scss/components/_ad-panel.scss
+++ b/scss/components/_ad-panel.scss
@@ -4,6 +4,15 @@
   bottom: 64px;
   width: 100%;
 
+  .oo-ad-screen-panel-click-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: $zindex-ad-screen-panel-click-layer;
+  }
+
   .oo-ad-top-bar {
     display: -webkit-flex;
     display: flex;


### PR DESCRIPTION
These changes should fix two issues:
- Ads can't be clicked and therefore can't be paused/unpaused on iPad.
- Clicking on an ad on desktop pauses the ad but doesn't trigger a click-through.

Both of these issues only occur when using the **Pulse** ad plugin. 