### PR TITLE
[PBW-6113] - Fix for CC's being truncated on iPhone

### DIFF
--- a/scss/components/_webvtt.scss
+++ b/scss/components/_webvtt.scss
@@ -26,7 +26,7 @@ video::-webkit-media-text-track-background {
 
 video::-webkit-media-text-track-display {
   position: relative;
-  top: 76% !important;
+  top: auto !important;
   bottom: 20px;
   background-color: transparent !important;
   padding: 1px !important;


### PR DESCRIPTION
Looks like the CC's where being squeezed between the `top` and `bottom` properties on smaller screens. 