### PR TITLE
[PBW-6113] - Increased horizontal space for native CC's

### DIFF
--- a/scss/components/_webvtt.scss
+++ b/scss/components/_webvtt.scss
@@ -28,9 +28,10 @@ video::-webkit-media-text-track-display {
   position: relative;
   top: auto !important;
   bottom: 20px;
+  width: 100% !important;
   background-color: transparent !important;
   padding: 1px !important;
-  margin: 0! important;
+  margin: 0 !important;
   font: 16px Arial, Helvetica, sans-serif;
   color: #fff !important;
   text-shadow: 1px 1px 2px black !important;


### PR DESCRIPTION
Sorry, I saw this after I submitted the previous PR. The CC container wasn't fully expanding, so on iPhone the CC's were growing vertically and it was hard to watch the video.