### PR TITLE
Bundle skin.json with html5-skin

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This simple test HTML page can also be hosted on your environment to showcase ht
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <!-- V4 JS core and at least one video plugin is required. Plugins such as skin, discovery and Advertising need to be loaded separately -->
   <script src="//player.ooyala.com/static/v4/stable/latest/core.min.js"></script>
   <script src="//player.ooyala.com/static/v4/stable/latest/video-plugin/main_html5.min.js"></script>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ This simple test HTML page can also be hosted on your environment to showcase ht
   var playerParam = {
     "pcode": "YOUR_PCODE",
     "playerBrandingId": "YOUR_PLAYER_ID",
-    "debug":true
+    "debug":true,
+    "skin": {
+      // Default config (./config/skin.json) contains the configuration setting for player skin. Change to your local config when necessary.
+      "config": ""
+    }
   };
 
   OO.ready(function() {

--- a/README.md
+++ b/README.md
@@ -31,11 +31,7 @@ This simple test HTML page can also be hosted on your environment to showcase ht
   var playerParam = {
     "pcode": "YOUR_PCODE",
     "playerBrandingId": "YOUR_PLAYER_ID",
-    "debug":true,
-    "skin": {
-      // Config contains the configuration setting for player skin. Change to your local config when necessary.
-      "config": "//player.ooyala.com/static/v4/stable/latest/skin-plugin/skin.json"
-    }
+    "debug":true
   };
 
   OO.ready(function() {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This simple test HTML page can also be hosted on your environment to showcase ht
     "playerBrandingId": "YOUR_PLAYER_ID",
     "debug":true,
     "skin": {
-      // Default config (./config/skin.json) contains the configuration setting for player skin. Change to your local config when necessary.
+      // config contains the configuration setting for player skin. Change to your local config when necessary.
       "config": ""
     }
   };

--- a/amp_iframe.html
+++ b/amp_iframe.html
@@ -16,6 +16,7 @@
       "pcode": queryParams.match(/pcode=([^&]*)/)[1],
       "playerBrandingId": queryParams.match(/pbid=([^&]*)/)[1],
       "skin": {
+        "config": "",
         "inline": {"shareScreen": {"embed": {"source": "<iframe width='640' height='480' frameborder='0' allowfullscreen src='//player.ooyala.com/static/v4/stable/latest/skin-plugin/iframe.html?ec=<ASSET_ID>&pbid=<PLAYER_ID>&pcode=<PUBLISHER_ID>'></iframe>"}}}
       }
     };

--- a/amp_iframe.html
+++ b/amp_iframe.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html style="padding:0; margin:0; width:100%; height:100%; overflow:hidden">
 <head>
+  <meta charset="utf-8">
   <script src="//player.ooyala.com/static/v4/stable/latest/core.min.js"></script>
   <script src="//player.ooyala.com/static/v4/stable/latest/video-plugin/main_html5.min.js"></script>
   <script src="//player.ooyala.com/static/v4/stable/latest/skin-plugin/html5-skin.min.js"></script>

--- a/amp_iframe.html
+++ b/amp_iframe.html
@@ -15,7 +15,6 @@
       "pcode": queryParams.match(/pcode=([^&]*)/)[1],
       "playerBrandingId": queryParams.match(/pbid=([^&]*)/)[1],
       "skin": {
-        "config": "//player.ooyala.com/static/v4/stable/latest/skin-plugin/skin.json",
         "inline": {"shareScreen": {"embed": {"source": "<iframe width='640' height='480' frameborder='0' allowfullscreen src='//player.ooyala.com/static/v4/stable/latest/skin-plugin/iframe.html?ec=<ASSET_ID>&pbid=<PLAYER_ID>&pcode=<PUBLISHER_ID>'></iframe>"}}}
       }
     };

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@ var gulp        = require('gulp'),
     browserify  = require('browserify'),
     watchify    = require('watchify'),
     reactify    = require('reactify'),
+    bulkify     = require('bulkify'),
     source      = require('vinyl-source-stream'),
     buffer      = require('vinyl-buffer'),
     gutil       = require('gulp-util'),
@@ -42,7 +43,7 @@ function buildJS(file, hash, watch, ugly, sourcemap, debug, externalReact) {
   var props ={
     entries: ['./js/controller.js'],
     debug: debug,
-    transform:    [[reactify, {}]],
+    transform:    [reactify, bulkify],
     cache: {},
     packageCache: {}
   };

--- a/iframe.html
+++ b/iframe.html
@@ -18,6 +18,7 @@
       "pcode": queryParams.match(/pcode=([^&]*)/)[1],
       "playerBrandingId": queryParams.match(/pbid=([^&]*)/)[1],
       "skin": {
+        "config": "",
         "inline": {"shareScreen": {"embed": {"source": "<iframe width='640' height='480' frameborder='0' allowfullscreen src='//player.ooyala.com/static/v4/stable/latest/skin-plugin/iframe.html?ec=<ASSET_ID>&pbid=<PLAYER_ID>&pcode=<PUBLISHER_ID>'></iframe>"}}}
       }
     };

--- a/iframe.html
+++ b/iframe.html
@@ -17,7 +17,6 @@
       "pcode": queryParams.match(/pcode=([^&]*)/)[1],
       "playerBrandingId": queryParams.match(/pbid=([^&]*)/)[1],
       "skin": {
-        "config": "//player.ooyala.com/static/v4/stable/latest/skin-plugin/skin.json",
         "inline": {"shareScreen": {"embed": {"source": "<iframe width='640' height='480' frameborder='0' allowfullscreen src='//player.ooyala.com/static/v4/stable/latest/skin-plugin/iframe.html?ec=<ASSET_ID>&pbid=<PLAYER_ID>&pcode=<PUBLISHER_ID>'></iframe>"}}}
       }
     };

--- a/iframe.html
+++ b/iframe.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html style="padding:0; margin:0; width:100%; height:100%; overflow:hidden">
 <head>
+  <meta charset="utf-8">
   <script src="//player.ooyala.com/static/v4/stable/latest/core.min.js"></script>
   <script src="//player.ooyala.com/static/v4/stable/latest/video-plugin/main_html5.min.js"></script>
   <script src="//player.ooyala.com/static/v4/stable/latest/video-plugin/osmf_flash.min.js"></script>

--- a/js/controller.js
+++ b/js/controller.js
@@ -8,7 +8,9 @@ var React = require('react'),
     AccessibilityControls = require('./components/accessibilityControls'),
     Fullscreen = require('screenfull'),
     Skin = require('./skin'),
-    SkinJSON = require('../config/skin');
+    SkinJSON = require('../config/skin'),
+    Bulk = require('bulk-require'),
+    Localization = Bulk('./config', ['languageFiles/*.json']);
 
 OO.plugin("Html5Skin", function (OO, _, $, W) {
   //Check if the player is at least v4. If not, the skin cannot load.
@@ -228,20 +230,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       $.extend(true, SkinJSON, params.skin.inline);
       //override state settings with defaults from skin config and possible local storage settings
       $.extend(true, this.state.closedCaptionOptions, SkinJSON.closedCaptionOptions, settings.closedCaptionOptions);
-
-      //load language jsons
-      var tmpLocalizableStrings = {};
-      SkinJSON.localization.availableLanguageFile.forEach(function(languageObj){
-        $.getJSON(languageObj.languageFile, _.bind(function(data) {
-          tmpLocalizableStrings[languageObj.language] = data;
-          this.renderSkin();
-        }, this));
-      }, this);
-
       this.state.config = SkinJSON;
 
       this.skin = ReactDOM.render(
-        React.createElement(Skin, {skinConfig: SkinJSON, localizableStrings: tmpLocalizableStrings, language: Utils.getLanguageToUse(SkinJSON), controller: this, closedCaptionOptions: this.state.closedCaptionOptions, pauseAnimationDisabled: this.state.pauseAnimationDisabled}), document.querySelector("#" + this.state.elementId + " .oo-player-skin")
+        React.createElement(Skin, {skinConfig: SkinJSON, localizableStrings: Localization.languageFiles, language: Utils.getLanguageToUse(SkinJSON), controller: this, closedCaptionOptions: this.state.closedCaptionOptions, pauseAnimationDisabled: this.state.pauseAnimationDisabled}), document.querySelector("#" + this.state.elementId + " .oo-player-skin")
       );
       var accessibilityControls = new AccessibilityControls(this); //keyboard support
       this.state.configLoaded = true;

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "devDependencies": {
     "browserify": "13.0.0",
+    "bulk-require": "^1.0.0",
+    "bulkify": "^1.4.2",
     "git-rev": "0.2.1",
     "graceful-fs": "*",
     "gulp": "3.9.1",

--- a/sample.html
+++ b/sample.html
@@ -18,7 +18,6 @@
     "playerBrandingId": "26e2e3c1049c4e70ae08a242638b5c40",
     'debug':true,
     "skin": {
-      "config": "//player.ooyala.com/static/v4/stable/latest/skin-plugin/skin.json",
       "inline": {"shareScreen": {"embed": {"source": "<iframe width='640' height='480' frameborder='0' allowfullscreen src='//player.ooyala.com/static/v4/stable/latest/skin-plugin/iframe.html?ec=<ASSET_ID>&pbid=<PLAYER_ID>&pcode=<PUBLISHER_ID>'></iframe>"}}}
     }
   };

--- a/sample.html
+++ b/sample.html
@@ -19,6 +19,7 @@
     "playerBrandingId": "26e2e3c1049c4e70ae08a242638b5c40",
     'debug':true,
     "skin": {
+      "config": "",
       "inline": {"shareScreen": {"embed": {"source": "<iframe width='640' height='480' frameborder='0' allowfullscreen src='//player.ooyala.com/static/v4/stable/latest/skin-plugin/iframe.html?ec=<ASSET_ID>&pbid=<PLAYER_ID>&pcode=<PUBLISHER_ID>'></iframe>"}}}
     }
   };

--- a/sample.html
+++ b/sample.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+  <meta charset="utf-8">
   <script src="//player.ooyala.com/static/v4/stable/latest/core.min.js"></script>
   <script src="//player.ooyala.com/static/v4/stable/latest/video-plugin/main_html5.min.js"></script>
   <script src="//player.ooyala.com/static/v4/stable/latest/video-plugin/osmf_flash.min.js"></script>

--- a/tests/components/scrubberBar-test.js
+++ b/tests/components/scrubberBar-test.js
@@ -3,9 +3,6 @@ jest.dontMock('../../js/components/scrubberBar')
     .dontMock('../../js/components/thumbnail')
     .dontMock('../../js/components/thumbnailCarousel')
     .dontMock('../../js/constants/constants')
-    .dontMock('../../config/en.json')
-    .dontMock('../../config/es.json')
-    .dontMock('../../config/zh.json')
     .dontMock('../../config/skin.json');
 
 var React = require('react');

--- a/tests/components/sharePanel-test.js
+++ b/tests/components/sharePanel-test.js
@@ -1,17 +1,17 @@
 jest.dontMock('../../js/components/sharePanel')
     .dontMock('../../js/components/utils')
     .dontMock('../../js/constants/constants')
-    .dontMock('../../config/en.json')
-    .dontMock('../../config/es.json')
-    .dontMock('../../config/zh.json');
+    .dontMock('../../config/languageFiles/en.json')
+    .dontMock('../../config/languageFiles/es.json')
+    .dontMock('../../config/languageFiles/zh.json');
 
 var React = require('react');
 var TestUtils = require('react-addons-test-utils');
 var CONSTANTS = require('../../js/constants/constants');
 var SharePanel = require('../../js/components/sharePanel');
-var en = require('../../config/en.json'),
-    es = require('../../config/es.json'),
-    zh = require('../../config/zh.json');
+var en = require('../../config/languageFiles/en.json'),
+    es = require('../../config/languageFiles/es.json'),
+    zh = require('../../config/languageFiles/zh.json');
 
 //manual mock of OO.ready player skin params
 var playerParam = {

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -209,6 +209,13 @@ OO = {
      */
 
     var Html5Skin = exposeStaticApi.prototype; // public object used to expose private object for testing
+    var elementId = 'adrfgyi';
+
+    //setup document body for valid DOM elements
+    document.body.innerHTML =
+      '<div id='+elementId+'>' +
+      '  <div class="oo-player-skin" />' +
+      '</div>';
 
     //test mb subscribe
     window._.bind = function() {};
@@ -217,11 +224,14 @@ OO = {
     Html5Skin.subscribeBasicPlaybackEvents.call(controllerMock);
     Html5Skin.externalPluginSubscription.call(controllerMock);
 
-    // test player state
-    Html5Skin.onPlayerCreated.call(controllerMock, 'customerUi', 1, {skin:{config:{}}}, {});
+    //test player state
+    var tempSkin = controllerMock.skin;
+    Html5Skin.onPlayerCreated.call(controllerMock, 'customerUi', elementId, {skin:{config:{}}}, {});
+    controllerMock.skin = tempSkin; //reset skin, onPlayerCreated updates skin
 
+    var tempMainVideoElement = controllerMock.state.mainVideoElement;
     Html5Skin.onVcVideoElementCreated.call(controllerMock, 'customerUi', {videoId: OO.VIDEO.MAIN});
-    controllerMock.state.mainVideoElement = {addClass: function(a) {}, removeClass: function(a) {}, get: function(a) { return { webkitSupportsFullscreen: true, webkitEnterFullscreen: function() {}, webkitExitFullscreen: function() {}, addEventListener: function(a,b) {}}}}
+    controllerMock.state.mainVideoElement = tempMainVideoElement;
 
     Html5Skin.metaDataLoaded.call(controllerMock);
     Html5Skin.onAuthorizationFetched.call(controllerMock, 'customerUi', {streams: [{is_live_stream: true}]});

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -188,7 +188,7 @@ OO = {
       closePopovers: function() {},
       setVolume: function(a) {},
       toggleVideoQualityPopOver: function(a) {},
-      setClosedCaptionsInfo: function() {},
+      setClosedCaptionsInfo: function(a) {},
       setClosedCaptionsLanguage: function() {},
       displayMoreOptionsScreen: function(a) {},
       closeMoreOptionsScreen: function() {},
@@ -196,11 +196,13 @@ OO = {
       renderSkin: function() {window.isSkinRendered = true;},
       cancelTimer: function() {window.isTimerCanceled = true;},
       startHideControlBarTimer: function() {},
+      startHideVolumeSliderTimer: function() {},
       hideControlBar: function() {window.isControlBarHidden = true;},
       hideVolumeSliderBar: function() {window.isVolumeSliderBarHidden = true;},
       updateAspectRatio: function() {},
       calculateAspectRatio: function(a,b) {},
-      setAspectRatio: function() {window.isAspectRatioSet = true;}
+      setAspectRatio: function() {window.isAspectRatioSet = true;},
+      createPluginElements: function() {}
     };
 
 
@@ -227,6 +229,8 @@ OO = {
     //test player state
     var tempSkin = controllerMock.skin;
     Html5Skin.onPlayerCreated.call(controllerMock, 'customerUi', elementId, {skin:{config:{}}}, {});
+    Html5Skin.loadConfigData.call(controllerMock, {skin:{config:{}}}, {});
+    Html5Skin.createPluginElements.call(controllerMock);
     controllerMock.skin = tempSkin; //reset skin, onPlayerCreated updates skin
 
     var tempMainVideoElement = controllerMock.state.mainVideoElement;
@@ -439,8 +443,10 @@ OO = {
     Html5Skin.sendDiscoveryDisplayEvent.call(controllerMock, CONSTANTS.SCREEN.DISCOVERY_SCREEN);
     Html5Skin.toggleVideoQualityPopOver.call(controllerMock);
     Html5Skin.toggleClosedCaptionPopOver.call(controllerMock);
+    Html5Skin.closePopovers.call(controllerMock);
     Html5Skin.receiveVideoQualityChangeEvent.call(controllerMock, null, 312);
     Html5Skin.sendVideoQualityChangeEvent.call(controllerMock, {id:2});
+    Html5Skin.setClosedCaptionsInfo.call(controllerMock, elementId);
 
     Html5Skin.setClosedCaptionsLanguage.call(controllerMock);
     controllerMock.state.closedCaptionOptions.availableLanguages = null;
@@ -481,6 +487,7 @@ OO = {
 
     // test control bar
     Html5Skin.startHideControlBarTimer.call(controllerMock);
+    Html5Skin.startHideVolumeSliderTimer.call(controllerMock);
 
     Html5Skin.showControlBar.call(controllerMock);
     window.showControlBarVisible = controllerMock.state.controlBarVisible;
@@ -511,6 +518,7 @@ OO = {
     //test destroy functions last
     Html5Skin.onEmbedCodeChanged.call(controllerMock, 'customerUi', 'RmZW4zcDo6KqkTIhn1LnowEZyUYn5Tb2', {});
     Html5Skin.onAssetChanged.call(controllerMock, 'customerUi', {content: {streams: [{is_live_stream: true}], title: 'Title', posterImages: [{url:'www.ooyala.com'}]}});
+    Html5Skin.onAssetUpdated.call(controllerMock, 'customerUi', {content: {streams: [{is_live_stream: true}], title: 'Title', posterImages: [{url:'www.ooyala.com'}]}});
     controllerMock.state.elementId = 'oo-video';
     Html5Skin.onPlayerDestroy.call(controllerMock, 'customerUi');
   }

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -227,13 +227,13 @@ OO = {
     Html5Skin.externalPluginSubscription.call(controllerMock);
 
     //test player state
-    var tempSkin = controllerMock.skin;
+    var tempSkin = $.extend(true, {}, controllerMock.skin);
     Html5Skin.onPlayerCreated.call(controllerMock, 'customerUi', elementId, {skin:{config:{}}}, {});
     Html5Skin.loadConfigData.call(controllerMock, {skin:{config:{}}}, {});
     Html5Skin.createPluginElements.call(controllerMock);
     controllerMock.skin = tempSkin; //reset skin, onPlayerCreated updates skin
 
-    var tempMainVideoElement = controllerMock.state.mainVideoElement;
+    var tempMainVideoElement = $.extend(true, {}, controllerMock.state.mainVideoElement);
     Html5Skin.onVcVideoElementCreated.call(controllerMock, 'customerUi', {videoId: OO.VIDEO.MAIN});
     controllerMock.state.mainVideoElement = tempMainVideoElement;
 


### PR DESCRIPTION
1.) Import and bundle skin.json AND all JSON lang files (en, es, zh)
2.) Replace jQuery ajax requests ($.getJSON) with imported skin.json and JSON lang files
3.) update unit test to work with updates
4.) remove config/skin.json param in html files
5.) our html files now require charset utf-8 because language strings are loaded from external js file instead of ajax, this is standard for all multi-lingal sites
6.) if config (skin.json) param or lang jsons (en, es, zh) exist load via ajax for backwards compatibility, else use defaults bundled in app
7.) must be merged with - https://github.com/ooyala/skin-config/pull/154