### PR TITLE
[PBI-1977] Add current timestamp to INITIAL_PLAY

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1096,7 +1096,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     togglePlayPause: function() {
       switch (this.state.playerState) {
         case CONSTANTS.STATE.START:
-          this.mb.publish(OO.EVENTS.INITIAL_PLAY);
+          this.mb.publish(OO.EVENTS.INITIAL_PLAY, Date.now());
           break;
         case CONSTANTS.STATE.END:
           if(Utils.isAndroid() || Utils.isIos()) {


### PR DESCRIPTION
Used for livestream playhead calculation for ads