### PR TITLE
[PBW-5932] Implemented text customization for discovery screen

### DIFF
--- a/js/components/discoverItem.js
+++ b/js/components/discoverItem.js
@@ -30,6 +30,11 @@ var DiscoverItem = React.createClass({
       backgroundImage: "url('" + this.props.src + "')"
     };
 
+    var itemTitleStyle = {
+      color: Utils.getPropertyValue(this.props.skinConfig, 'discoveryScreen.contentTitle.font.color'),
+      fontFamily: Utils.getPropertyValue(this.props.skinConfig, 'discoveryScreen.contentTitle.font.fontFamily')
+    };
+
     return (
       <div className="oo-discovery-image-wrapper-style">
         <div className="oo-discovery-wrapper">
@@ -38,9 +43,23 @@ var DiscoverItem = React.createClass({
           </a>
           {this.props.children}
         </div>
-        <div className={this.props.contentTitleClassName} dangerouslySetInnerHTML={Utils.createMarkup(this.props.contentTitle)}></div>
+        <div className={this.props.contentTitleClassName} style={itemTitleStyle} dangerouslySetInnerHTML={Utils.createMarkup(this.props.contentTitle)}></div>
       </div>
     );
   }
 });
+
+DiscoverItem.propTypes = {
+  skinConfig: React.PropTypes.shape({
+    discoveryScreen: React.PropTypes.shape({
+      contentTitle: React.PropTypes.shape({
+        font: React.PropTypes.shape({
+          color: React.PropTypes.string,
+          fontFamily: React.PropTypes.string
+        })
+      })
+    })
+  })
+};
+
 module.exports = DiscoverItem;

--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -264,6 +264,33 @@ var Utils = {
   },
 
   /**
+   * Safely gets the value of an object's nested property.
+   *
+   * @function getPropertyValue
+   * @param {Object} object - The object we want to extract the property form
+   * @param {String} propertyPath - A path that points to a nested property in the object with a form like 'prop.nestedProp1.nestedProp2'
+   * @param {Object} defaltValue - (Optional) A default value to return when the property is undefined
+   * @return {Object} - The value of the nested property, the default value if nested property was undefined
+   */
+  getPropertyValue: function(object, propertyPath, defaltValue) {
+    var value = null;
+    var currentObject = object;
+    var currentProp = null;
+
+    try {
+      var props = propertyPath.split('.');
+
+      for (var i = 0; i < props.length; i++) {
+        currentProp = props[i];
+        currentObject = value = currentObject[currentProp];
+      }
+      return value || defaltValue;
+    } catch (err) {
+      return defaltValue;
+    }
+  },
+
+  /**
   * Highlight the given element for hover effects
   *
   * @function Highlight

--- a/js/controller.js
+++ b/js/controller.js
@@ -1231,9 +1231,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         "custom" : { "source" : screen}
       };
       this.mb.publish(OO.EVENTS.DISCOVERY_API.SEND_DISPLAY_EVENT, eventData);
-      if (screen == CONSTANTS.SCREEN.END_SCREEN) {
-        this.skin.props.skinConfig.discoveryScreen.showCountDownTimerOnEndScreen = true;
-      }
     },
 
     toggleVideoQualityPopOver: function() {

--- a/js/views/contentScreen.js
+++ b/js/views/contentScreen.js
@@ -25,9 +25,17 @@ var ContentScreen = React.createClass({
     ) :
     null;
 
+    var titleBarStyle = {};
+    switch (this.props.screen) {
+      case CONSTANTS.SCREEN.DISCOVERY_SCREEN:
+        titleBarStyle.fontFamily = Utils.getPropertyValue(this.props.skinConfig, 'discoveryScreen.panelTitle.titleFont.fontFamily');
+        titleBarStyle.color = Utils.getPropertyValue(this.props.skinConfig, 'discoveryScreen.panelTitle.titleFont.color');
+        break;
+    }
+
     //localized title bar, show nothing if no title text
     var titleBar = this.props.titleText ? (
-      <div className="oo-content-screen-title">
+      <div className="oo-content-screen-title" style={titleBarStyle}>
         {Utils.getLocalizedString(this.props.language, this.props.titleText, this.props.localizableStrings)}
         <Icon {...this.props} icon={this.props.icon}/>
         {this.props.element}
@@ -50,7 +58,17 @@ var ContentScreen = React.createClass({
 });
 
 ContentScreen.propTypes = {
-  element: React.PropTypes.element
+  element: React.PropTypes.element,
+  skinConfig: React.PropTypes.shape({
+    discoveryScreen: React.PropTypes.shape({
+      panelTitle: React.PropTypes.shape({
+        titleFont: React.PropTypes.shape({
+          color: React.PropTypes.string,
+          fontFamily: React.PropTypes.string
+        })
+      })
+    })
+  })
 };
 
 ContentScreen.defaultProps = {

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -143,6 +143,17 @@ describe('Utils', function () {
     expect(localizedString).toBe("");
   });
 
+  it('tests getPropertyValue', function () {
+    var defaultVal = Utils.getPropertyValue({}, 'property.nestedProp', 'default');
+    expect(defaultVal).toEqual('default');
+
+    var undefinedVal = Utils.getPropertyValue({}, 'property.nestedProp');
+    expect(undefinedVal).toBeUndefined();
+
+    var existingVal = Utils.getPropertyValue({ property: { nestedProp: 'value' } }, 'property.nestedProp');
+    expect(existingVal).toEqual('value');
+  });
+
   it('tests highlight', function () {
     var div = document.createElement('div');
     var opacity = '0.6';


### PR DESCRIPTION
I also fixed an issue that prevented the end screen's countdown timer from being disabled. I was playing with default props but it turns out that they are applied with a shallow merge, so if the main property is not undefined (like this.props.skinConfig) the nested property defaults don't get applied. I added a helper function to prevent these changes from crashing if the user forgets to define a property on the skin.