### PR TITLE
[PBW-6065] - Automatically setting docUrl to frame's parent url when not explicitly set

### DIFF
--- a/iframe.html
+++ b/iframe.html
@@ -27,6 +27,8 @@
     var docUrl = undefined;
     if (!!queryParams.match(/docUrl=([^&]*)/)) {
       playerParam["docUrl"] = decodeURIComponent(queryParams.match(/docUrl=([^&]*)/)[1]);
+    } else {
+      playerParam["docUrl"] = document.referrer;
     }
 
     // Parse standard Ooyala player runtime options

--- a/iframe.html
+++ b/iframe.html
@@ -27,8 +27,10 @@
     var docUrl = undefined;
     if (!!queryParams.match(/docUrl=([^&]*)/)) {
       playerParam["docUrl"] = decodeURIComponent(queryParams.match(/docUrl=([^&]*)/)[1]);
-    } else {
+    } else if (document.referrer) {
       playerParam["docUrl"] = document.referrer;
+    } else {
+      console.log("iframe.html - document.referrer was not set");
     }
 
     // Parse standard Ooyala player runtime options


### PR DESCRIPTION
This will automatically get the parent frame's url and use it for analytics, without the customer having to set it via `docUrl`. Passing `docUrl` through the query string will override this.
