### PR TITLE
[PLAYER-213] Publish SET_EMBED_CODE with playerParam on discovery click

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1244,7 +1244,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.renderSkin();
         this.mb.publish(OO.EVENTS.PAUSE);
         if (selectedContentData.clickedVideo.embed_code){
-          this.mb.publish(OO.EVENTS.SET_EMBED_CODE, selectedContentData.clickedVideo.embed_code);
+          this.mb.publish(OO.EVENTS.SET_EMBED_CODE, selectedContentData.clickedVideo.embed_code,
+                          this.state.playerParam);
         }
         else if (selectedContentData.clickedVideo.asset){
           this.mb.publish(OO.EVENTS.SET_ASSET, selectedContentData.clickedVideo.asset);


### PR DESCRIPTION
The lack of passing the playerParam caused an issue where the ad set code would not get propagated to subsequently clicked discovery videos.