### PR TITLE
override 'pointer-events: none' from oo-interactive-container

### DIFF
--- a/scss/components/_ad-overlay.scss
+++ b/scss/components/_ad-overlay.scss
@@ -5,6 +5,7 @@
   margin: 0;
   padding: 0;
   overflow: hidden;
+  pointer-events: auto;
 
   .oo-ad-overlay-close-button {
     display: inline-block;


### PR DESCRIPTION
- fixes ad selection issue