### PR TITLE
onSkinMetaDataFetched and deep merge updates

### DIFF
--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -398,7 +398,7 @@ var ControlBar = React.createClass({
       }
 
       //filter out disabled buttons
-      if (defaultItems[k].enabled == false) {
+      if (defaultItems[k].location === "none") {
         continue;
       }
 

--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -431,34 +431,38 @@ var Utils = {
    * @function arrayDeepMerge
    * @param {Array} target - An array that will receive new items if additional items are passed
    * @param {Array} source - An array containing additional items to merge into target
-   * @param {Object} optionsArgument - optional parameters passed, i.e. arrayMerge function
+   * @param {Object} optionsArgument - optional parameters passed, i.e. arrayMerge, swap, unionBy, clone
    * @returns {Array} new merged array with items from both target and source
    */
   arrayDeepMerge: function(target, source, optionsArgument) {
+    var targetArray = optionsArgument.swap ? source : target;
+    var sourceArray = optionsArgument.swap ? target : source;
     var self = this;
     var destination = [];
-    destination = source.slice();
-    target.forEach(function(targetItem, i) {
+    destination = sourceArray.slice();
+
+    targetArray.forEach(function(targetItem, i) {
       if (typeof destination[i] === 'undefined') {
         destination[i] = self._cloneIfNecessary(targetItem, optionsArgument);
       }
       else if (self._isMergeableObject(targetItem)) {
         // custom merge for buttons array, used to maintain source sort order
-        if (targetItem.name) {
-          source.forEach(function(sourceItem, j) {
+        if (targetItem[optionsArgument.unionBy]) {
+          sourceArray.forEach(function(sourceItem, j) {
             //gracefully merge buttons by name
-            if (targetItem.name === sourceItem.name) {
-              destination[j] = DeepMerge(targetItem, sourceItem, optionsArgument);
+            if (targetItem[optionsArgument.unionBy] === sourceItem[optionsArgument.unionBy]) {
+              var targetObject = optionsArgument.swap ? sourceItem : targetItem;
+              var sourceObject = optionsArgument.swap ? targetItem : sourceItem;
+              destination[j] = DeepMerge(targetObject, sourceObject, optionsArgument);
             }
           });
         }
         // default array merge
         else {
-          destination[i] = DeepMerge(targetItem, source[i], optionsArgument);
+          destination[i] = DeepMerge(targetItem, sourceArray[i], optionsArgument);
         }
-
       }
-      else if (source.indexOf(targetItem) === -1) {
+      else if (sourceArray.indexOf(targetItem) === -1) {
         destination.push(self._cloneIfNecessary(targetItem, optionsArgument));
       }
     });

--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -432,21 +432,25 @@ var Utils = {
    * @function arrayDeepMerge
    * @param {Array} target - An array that will receive new items if additional items are passed
    * @param {Array} source - An array containing additional items to merge into target
-   * @param {Object} optionsArgument - optional parameters passed, i.e. arrayMerge, swap, unionBy, clone, arrayFusion
+   * @param {Object} optionsArgument - parameters passed to parent DeepMerge function, i.e. -
+   *        arrayMerge - https://github.com/KyleAMathews/deepmerge#arraymerge
+   *        clone - https://github.com/KyleAMathews/deepmerge#clone
+   *        arrayUnionBy - key used to compare Objects being merged, i.e. button name
+   *        arrayFusion - method used to merge arrays ['replace', 'prepend']
+   *        arraySwap - swaps target/source
    * @returns {Array} new merged array with items from both target and source
    */
   arrayDeepMerge: function(target, source, optionsArgument) {
-    // replaces target with source, no merge
+    // returns source, no merge
     if (optionsArgument.arrayFusion === 'replace') {
       return source;
     }
 
-    var targetArray = optionsArgument.swap ? source : target;
-    var sourceArray = optionsArgument.swap ? target : source;
+    var targetArray = optionsArgument.arraySwap ? source : target;
+    var sourceArray = optionsArgument.arraySwap ? target : source;
     var self = this;
-    var uniqueSourceArray = sourceArray.slice();
-    var destination = [];
-    destination = targetArray.slice();
+    var uniqueSourceArray = sourceArray.slice(); //array used to keep track of objects that do not exist in target
+    var destination = targetArray.slice();
 
     sourceArray.forEach(function(sourceItem, i) {
       if (typeof destination[i] === 'undefined') {
@@ -454,18 +458,18 @@ var Utils = {
       }
       else if (self._isMergeableObject(sourceItem)) {
         // custom merge for buttons array, used to maintain source sort order
-        if (sourceItem[optionsArgument.unionBy]) {
+        if (sourceItem[optionsArgument.arrayUnionBy]) {
           targetArray.forEach(function(targetItem, j) {
             // gracefully merge buttons by name
-            if (sourceItem[optionsArgument.unionBy] === targetItem[optionsArgument.unionBy]) {
-              var targetObject = optionsArgument.swap ? sourceItem : targetItem;
-              var sourceObject = optionsArgument.swap ? targetItem : sourceItem;
+            if (sourceItem[optionsArgument.arrayUnionBy] === targetItem[optionsArgument.arrayUnionBy]) {
+              var targetObject = optionsArgument.arraySwap ? sourceItem : targetItem;
+              var sourceObject = optionsArgument.arraySwap ? targetItem : sourceItem;
               destination[j] = DeepMerge(targetObject, sourceObject, optionsArgument);
 
               // prunes uniqueSourceArray to unique items not in target
               if (optionsArgument.arrayFusion === 'prepend' && uniqueSourceArray && uniqueSourceArray.length) {
                 for (var x in uniqueSourceArray) {
-                  if (uniqueSourceArray[x][optionsArgument.unionBy] == sourceItem[optionsArgument.unionBy]) {
+                  if (uniqueSourceArray[x][optionsArgument.arrayUnionBy] === sourceItem[optionsArgument.arrayUnionBy]) {
                     uniqueSourceArray.splice(x, 1);
                     break;
                   }
@@ -488,7 +492,7 @@ var Utils = {
       var flexibleSpaceIndex = null;
       // find flexibleSpace btn index
       for (var y in destination) {
-        if (destination[y][optionsArgument.unionBy] === 'flexibleSpace') {
+        if (destination[y][optionsArgument.arrayUnionBy] === 'flexibleSpace') {
           flexibleSpaceIndex = parseInt(y);
           break;
         }

--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -443,7 +443,7 @@ var Utils = {
     var targetArray = optionsArgument.swap ? source : target;
     var sourceArray = optionsArgument.swap ? target : source;
     var self = this;
-    var sourceClone = sourceArray.slice();
+    var uniqueSourceArray = sourceArray.slice();
     var destination = [];
     destination = targetArray.slice();
 
@@ -461,11 +461,11 @@ var Utils = {
               var sourceObject = optionsArgument.swap ? targetItem : sourceItem;
               destination[j] = DeepMerge(targetObject, sourceObject, optionsArgument);
 
-              // prunes sourceClone to unique items not in target
-              if (optionsArgument.arrayFusion === 'concat' && sourceClone && sourceClone.length) {
-                for (var x in sourceClone) {
-                  if (sourceClone[x][optionsArgument.unionBy] == sourceItem[optionsArgument.unionBy]) {
-                    sourceClone.splice(x, 1);
+              // prunes uniqueSourceArray to unique items not in target
+              if (optionsArgument.arrayFusion === 'prepend' && uniqueSourceArray && uniqueSourceArray.length) {
+                for (var x in uniqueSourceArray) {
+                  if (uniqueSourceArray[x][optionsArgument.unionBy] == sourceItem[optionsArgument.unionBy]) {
+                    uniqueSourceArray.splice(x, 1);
                     break;
                   }
                 }
@@ -482,9 +482,26 @@ var Utils = {
         destination.push(self._cloneIfNecessary(sourceItem, optionsArgument));
       }
     });
-    // concat array of unique items to destination
-    if (optionsArgument.arrayFusion === 'concat' && sourceClone && sourceClone.length) {
-      destination = destination.concat(sourceClone);
+    // prepend uniqueSourceArray array of unique items to buttons after flexible space
+    if (optionsArgument.arrayFusion === 'prepend' && uniqueSourceArray && uniqueSourceArray.length) {
+      var flexibleSpaceIndex = null;
+      // find flexibleSpace btn index
+      for (var y in destination) {
+        if (destination[y][optionsArgument.unionBy] === 'flexibleSpace') {
+          flexibleSpaceIndex = parseInt(y);
+          break;
+        }
+      }
+      // loop through uniqueSourceArray array, add unique objects
+      // to destination array after flexible space btn
+      if (flexibleSpaceIndex) {
+        flexibleSpaceIndex += 1; //after flexible space
+        for (var z in uniqueSourceArray) {
+          destination.splice(flexibleSpaceIndex, 0, uniqueSourceArray[z]);
+        }
+      } else {
+        destination = destination.concat(uniqueSourceArray);
+      }
     }
     return destination;
   },

--- a/js/controller.js
+++ b/js/controller.js
@@ -234,6 +234,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       if (params.skin && params.skin.config) {
         $.getJSON(params.skin.config, function(data) {
           this.state.config = data;
+          this.loadConfigData(this.state.playerParam, this.state.persistentSettings, this.state.config, this.state.skinMetaData);
         }.bind(this));
       }
 

--- a/js/controller.js
+++ b/js/controller.js
@@ -798,8 +798,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       var arrayFusion = params.buttonMerge ? params.buttonMerge : 'replace';
 
       //override data in skin config with possible local storage settings, inline data input by user, and CMS settings in backlot/themebuilder
-      var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name'});
-      this.state.config = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name', arrayFusion:arrayFusion});
+      var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name'});
+      this.state.config = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', arrayFusion:arrayFusion});
       this.state.closedCaptionOptions = this.state.config.closedCaptionOptions;
 
       //load config language json if exist

--- a/js/controller.js
+++ b/js/controller.js
@@ -795,10 +795,11 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       var inlinePageParams = Utils.getPropertyValue(params, 'skin.inline') ? params.skin.inline : {};
       var customSkinJSON = data ? data : {};
       var metaDataSettings = skinMetaData ? skinMetaData : {};
+      var arrayFusion = params.buttonMerge ? params.buttonMerge : 'replace';
 
       //override data in skin config with possible local storage settings, inline data input by user, and CMS settings in backlot/themebuilder
-      var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name', swap:true});
-      this.state.config = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name'});
+      var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name'});
+      this.state.config = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name', arrayFusion:arrayFusion});
       this.state.closedCaptionOptions = this.state.config.closedCaptionOptions;
 
       //load config language json if exist

--- a/js/controller.js
+++ b/js/controller.js
@@ -30,6 +30,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     this.id = id;
     this.state = {
       "playerParam": {},
+      "skinMetaData": {},
       "persistentSettings": {
         "closedCaptionOptions": {}
       },
@@ -149,6 +150,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.mb.subscribe(OO.EVENTS.CONTENT_TREE_FETCHED, 'customerUi', _.bind(this.onContentTreeFetched, this));
       this.mb.subscribe(OO.EVENTS.THUMBNAILS_FETCHED, 'customerUi', _.bind(this.onThumbnailsFetched, this));//xenia: to be replaced by a more appropriate event
       this.mb.subscribe(OO.EVENTS.AUTHORIZATION_FETCHED, 'customerUi', _.bind(this.onAuthorizationFetched, this));
+      this.mb.subscribe(OO.EVENTS.SKIN_METADATA_FETCHED, 'customerUi', _.bind(this.onSkinMetaDataFetched, this));
       this.mb.subscribe(OO.EVENTS.ASSET_CHANGED, 'customerUi', _.bind(this.onAssetChanged, this));
       this.mb.subscribe(OO.EVENTS.ASSET_UPDATED, 'customerUi', _.bind(this.onAssetUpdated, this));
       this.mb.subscribe(OO.EVENTS.PLAYBACK_READY, 'customerUi', _.bind(this.onPlaybackReady, this));
@@ -218,6 +220,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.state.mainVideoContainer = $("#" + elementId);
       this.state.mainVideoInnerWrapper = $("#" + elementId + " .innerWrapper");
       this.state.playerParam = params;
+      this.state.persistentSettings = settings;
       this.state.elementId = elementId;
       this.state.isMobile = Utils.isMobile();
       this.state.browserSupportsTouch = Utils.browserSupportsTouch();
@@ -230,12 +233,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       //load player with page level config param if exist
       if (params.skin && params.skin.config) {
         $.getJSON(params.skin.config, function(data) {
-          this.loadConfigData(params, settings, data);
+          this.state.config = data;
         }.bind(this));
-      }
-      //else load player with bundled config
-      else {
-        this.loadConfigData(params, settings);
       }
 
       var accessibilityControls = new AccessibilityControls(this); //keyboard support
@@ -301,6 +300,11 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.state.contentTree = contentTree;
       this.state.playerState = CONSTANTS.STATE.START;
       this.renderSkin({"contentTree": contentTree});
+    },
+
+    onSkinMetaDataFetched: function (event, skinMetaData) {
+      this.state.skinMetaData = skinMetaData;
+      this.loadConfigData(this.state.playerParam, this.state.persistentSettings, this.state.config, this.state.skinMetaData);
     },
 
     onThumbnailsFetched: function (event, thumbnails) {
@@ -783,19 +787,20 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
      *********************************************************************/
 
     //merge and load config data
-    loadConfigData: function(params, settings, data) {
-      if (data) {
-        SkinJSON = data;
-      }
+    loadConfigData: function(params, settings, data, skinMetaData) {
+      var localSettings = settings ? settings : {};
       var inlinePageParams = Utils.getPropertyValue(params, 'skin.inline') ? params.skin.inline : {};
+      var customSkinJSON = data ? data : {};
+      var metaDataSettings = skinMetaData ? skinMetaData : {};
 
-      //override data in skin config with possible local storage settings and inline data input by the user
-      this.state.config = SkinJSON = DeepMerge.all([SkinJSON, inlinePageParams, settings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils)});
+      //override data in skin config with possible local storage settings, inline data input by user, and CMS settings in backlot/themebuilder
+      var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name', swap:true});
+      this.state.config = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name'});
       this.state.closedCaptionOptions = this.state.config.closedCaptionOptions;
 
       //load config language json if exist
-      if (SkinJSON.localization.availableLanguageFile) {
-        SkinJSON.localization.availableLanguageFile.forEach(function(languageObj){
+      if (this.state.config.localization.availableLanguageFile) {
+        this.state.config.localization.availableLanguageFile.forEach(function(languageObj){
           if (languageObj.languageFile) {
             $.getJSON(languageObj.languageFile, function(data) {
               Localization.languageFiles[languageObj.language] = data;
@@ -805,12 +810,12 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       }
 
       //backwards compatibility with string parameters in skin.json
-      SkinJSON.upNext.timeToShow = Utils.convertStringToNumber(SkinJSON.upNext.timeToShow);
-      SkinJSON.discoveryScreen.countDownTime = Utils.convertStringToNumber(SkinJSON.discoveryScreen.countDownTime);
+      this.state.config.upNext.timeToShow = Utils.convertStringToNumber(this.state.config.upNext.timeToShow);
+      this.state.config.discoveryScreen.countDownTime = Utils.convertStringToNumber(this.state.config.discoveryScreen.countDownTime);
 
       //load player
       this.skin = ReactDOM.render(
-        React.createElement(Skin, {skinConfig: this.state.config, localizableStrings: Localization.languageFiles, language: Utils.getLanguageToUse(SkinJSON), controller: this, closedCaptionOptions: this.state.closedCaptionOptions, pauseAnimationDisabled: this.state.pauseAnimationDisabled}), document.querySelector("#" + this.state.elementId + " .oo-player-skin")
+        React.createElement(Skin, {skinConfig: this.state.config, localizableStrings: Localization.languageFiles, language: Utils.getLanguageToUse(this.state.config), controller: this, closedCaptionOptions: this.state.closedCaptionOptions, pauseAnimationDisabled: this.state.pauseAnimationDisabled}), document.querySelector("#" + this.state.elementId + " .oo-player-skin")
       );
       this.state.configLoaded = true;
       this.renderSkin();
@@ -1016,6 +1021,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       // player events
       this.mb.unsubscribe(OO.EVENTS.PLAYER_CREATED, 'customerUi');
       this.mb.unsubscribe(OO.EVENTS.CONTENT_TREE_FETCHED, 'customerUi');
+      this.mb.unsubscribe(OO.EVENTS.SKIN_METADATA_FETCHED, 'customerUi');
       this.mb.unsubscribe(OO.EVENTS.AUTHORIZATION_FETCHED, 'customerUi');
       this.mb.unsubscribe(OO.EVENTS.ASSET_CHANGED, 'customerUi');
       this.mb.unsubscribe(OO.EVENTS.ASSET_UPDATED, 'customerUi');

--- a/js/controller.js
+++ b/js/controller.js
@@ -234,8 +234,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       if (params.skin && params.skin.config) {
         $.getJSON(params.skin.config, function(data) {
           this.state.config = data;
-          this.loadConfigData(this.state.playerParam, this.state.persistentSettings, this.state.config, this.state.skinMetaData);
+          this.loadConfigData(this.state.playerParam, this.state.persistentSettings, data, this.state.skinMetaData);
         }.bind(this));
+      } else {
+        this.loadConfigData(this.state.playerParam, this.state.persistentSettings, this.state.config, this.state.skinMetaData);
       }
 
       var accessibilityControls = new AccessibilityControls(this); //keyboard support

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -1,5 +1,10 @@
 jest.dontMock('../../js/components/utils');
+jest.dontMock('deepmerge');
+jest.dontMock('../../config/skin');
+
 var Utils = require('../../js/components/utils');
+var DeepMerge = require('deepmerge');
+var SkinJSON = require('../../config/skin');
 
 describe('Utils', function () {
   it('tests the utility functions', function () {
@@ -212,5 +217,44 @@ describe('Utils', function () {
     var markup = 'This is &quot;markup&quot;';
     var html = Utils.createMarkup(markup);
     expect(html.__html).toBe(markup);
+  });
+
+  it('tests deep merge', function () {
+    var localSettings = {"closedCaptionOptions":{"windowColor":"Yellow","enabled":true, "backgroundOpacity":"0.2","textOpacity":"1"}};
+    var inlinePageParams = {"closedCaptionOptions":{"textColor":"Blue", "backgroundColor":"Green","windowColor":"White","windowOpacity":0.5},"buttons":{"desktopContent":[{"name":"ooyala","location":"ooyala","whenDoesNotFit":"ooyala","minWidth":85},{"name":"quality","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":85}]}};
+    var customSkinJSON = {"general":{"accentColor":"#448aff"},"closedCaptionOptions":{"enabled":true,"language":"en","fontType":"Proportional Sans-Serif"},"buttons":{"desktopContent":[{"name":"alice","location":"alice","whenDoesNotFit":"keep","minWidth":53},{"name":"volume","location":"controlBar","whenDoesNotFit":"keep","minWidth":240},{"name":"live","location":"controlBar","whenDoesNotFit":"keep","minWidth":65},{"name":"quality","location":"controlBar","whenDoesNotFit":"ooyala","minWidth":95,"alice":"video"}]}};
+    var metaDataSettings = {"closedCaptionOptions":{"fontSize":"Large","windowColor":"Green"},"buttons":{"desktopContent":[{"name":"share","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":45,"enabled":true},{"name":"volume","location":"controlBar","whenDoesNotFit":"keep","minWidth":45,"enabled":true},{"name":"fullscreen","location":"controlBar","whenDoesNotFit":"keep","minWidth":55,"enabled":true},{"name":"quality","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":45,"enabled":true}]},"general":{"accentColor":"#ffbb00","watermark":{"imageResource":{"url":"http://ak.c.ooyala.com/Uzbm46asiensk3opIgwfFn5KFemv/watermark147585568"},"position":"top-left","clickUrl":"","transparency":0.51,"scalingOption":"none","scalingPercentage":0}},"shareScreen":{"shareContent":["social","ooyala"],"socialContent":["twitter","lisa","google+","jason"]}};
+    var arrayFusion = 'replace';
+
+    var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name'});
+    var finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name', arrayFusion:arrayFusion});
+
+    // test merge hierarchy, keys from 5 objects should be merged into one object with correct priority
+    expect(finalConfig.closedCaptionOptions.textColor).toBe("Blue"); //from inlinePageParams
+    expect(finalConfig.closedCaptionOptions.windowOpacity).toBe(0.5); //from inlinePageParams
+    expect(finalConfig.closedCaptionOptions.backgroundColor).toBe("Green"); //from inlinePageParams
+    expect(finalConfig.closedCaptionOptions.windowColor).toBe("Yellow"); //from localSettings
+    expect(finalConfig.closedCaptionOptions.fontType).toBe("Proportional Sans-Serif"); //from customSkinJSON
+    expect(finalConfig.closedCaptionOptions.fontSize).toBe("Large"); //from metaDataSettings
+    expect(finalConfig.closedCaptionOptions.textEnhancement).toBe("Uniform"); //from SkinJSON
+
+    // test array merge for buttons (replace)
+    expect(finalConfig.buttons.desktopContent.length).toBe(inlinePageParams.buttons.desktopContent.length);
+    // test basic array merge
+    expect(finalConfig.shareScreen.shareContent[1]).toBe(SkinJSON.shareScreen.shareContent[1]);
+    expect(finalConfig.shareScreen.shareContent[2]).toBe(metaDataSettings.shareScreen.shareContent[1]);
+    expect(finalConfig.shareScreen.shareContent).toEqual(['social', 'embed', 'ooyala']);
+
+    arrayFusion = 'prepend';
+    mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name'});
+    finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name', arrayFusion:arrayFusion});
+
+    // test array merge for buttons (prepend)
+    expect(finalConfig.buttons.desktopContent.length).toBe(14);
+    // test new buttons are placed after flexibleSpace
+    expect(finalConfig.buttons.desktopContent[4].name).toBe("flexibleSpace");
+    expect(finalConfig.buttons.desktopContent[5].name).toBe("ooyala");
+    expect(finalConfig.buttons.desktopContent[6].name).toBe("alice");
+    expect(finalConfig.buttons.desktopContent[10].alice).toBe("video");
   });
 });

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -238,14 +238,26 @@ describe('Utils', function () {
   });
 
   it('tests deep merge', function () {
-    var localSettings = {"closedCaptionOptions":{"windowColor":"Yellow","enabled":true, "backgroundOpacity":"0.2","textOpacity":"1"}};
-    var inlinePageParams = {"closedCaptionOptions":{"textColor":"Blue", "backgroundColor":"Green","windowColor":"White","windowOpacity":0.5},"buttons":{"desktopContent":[{"name":"ooyala","location":"ooyala","whenDoesNotFit":"ooyala","minWidth":85},{"name":"quality","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":85}]}};
-    var customSkinJSON = {"general":{"accentColor":"#448aff"},"closedCaptionOptions":{"enabled":true,"language":"en","fontType":"Proportional Sans-Serif"},"buttons":{"desktopContent":[{"name":"alice","location":"alice","whenDoesNotFit":"keep","minWidth":53},{"name":"volume","location":"controlBar","whenDoesNotFit":"keep","minWidth":240},{"name":"live","location":"controlBar","whenDoesNotFit":"keep","minWidth":65},{"name":"quality","location":"controlBar","whenDoesNotFit":"ooyala","minWidth":95,"alice":"video"}]}};
-    var metaDataSettings = {"closedCaptionOptions":{"fontSize":"Large","windowColor":"Green"},"buttons":{"desktopContent":[{"name":"share","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":45,"enabled":true},{"name":"volume","location":"controlBar","whenDoesNotFit":"keep","minWidth":45,"enabled":true},{"name":"fullscreen","location":"controlBar","whenDoesNotFit":"keep","minWidth":55,"enabled":true},{"name":"quality","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":45,"enabled":true}]},"general":{"accentColor":"#ffbb00","watermark":{"imageResource":{"url":"http://ak.c.ooyala.com/Uzbm46asiensk3opIgwfFn5KFemv/watermark147585568"},"position":"top-left","clickUrl":"","transparency":0.51,"scalingOption":"none","scalingPercentage":0}},"shareScreen":{"shareContent":["social","ooyala"],"socialContent":["twitter","lisa","google+","jason"]}};
+    var localSettings = {
+      "closedCaptionOptions":{"windowColor":"Yellow","enabled":true, "backgroundOpacity":"0.2","textOpacity":"1"}
+    };
+    var inlinePageParams = {
+      "closedCaptionOptions":{"textColor":"Blue", "backgroundColor":"Green","windowColor":"White","windowOpacity":0.5},
+      "buttons":{"desktopContent":[{"name":"ooyala","location":"ooyala","whenDoesNotFit":"ooyala","minWidth":85},{"name":"quality","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":85}]}
+    };
+    var customSkinJSON = {
+      "closedCaptionOptions":{"enabled":true,"language":"en","fontType":"Proportional Sans-Serif"},
+      "buttons":{"desktopContent":[{"name":"alice","location":"alice","whenDoesNotFit":"keep","minWidth":53},{"name":"volume","location":"controlBar","whenDoesNotFit":"keep","minWidth":240},{"name":"live","location":"controlBar","whenDoesNotFit":"keep","minWidth":65},{"name":"quality","location":"controlBar","whenDoesNotFit":"ooyala","minWidth":95,"alice":"video"}]},
+      "general":{"accentColor":"#448aff"}
+    };
+    var metaDataSettings = {
+      "closedCaptionOptions":{"fontSize":"Large","windowColor":"Green"},
+      "buttons":{"desktopContent":[{"name":"share","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":45,"enabled":true},{"name":"volume","location":"controlBar","whenDoesNotFit":"keep","minWidth":45,"enabled":true},{"name":"fullscreen","location":"controlBar","whenDoesNotFit":"keep","minWidth":55,"enabled":true},{"name":"quality","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":45,"enabled":true}]},"general":{"accentColor":"#ffbb00","watermark":{"imageResource":{"url":"http://ak.c.ooyala.com/Uzbm46asiensk3opIgwfFn5KFemv/watermark147585568"},"position":"top-left","clickUrl":"","transparency":0.51,"scalingOption":"none","scalingPercentage":0}},"shareScreen":{"shareContent":["social","ooyala"],"socialContent":["twitter","lisa","google+","jason"]}
+    };
     var arrayFusion = 'replace';
 
-    var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name'});
-    var finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name', arrayFusion:arrayFusion});
+    var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name'});
+    var finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', arrayFusion:arrayFusion});
 
     // test merge hierarchy, keys from 5 objects should be merged into one object with correct priority
     expect(finalConfig.closedCaptionOptions.textColor).toBe("Blue"); //from inlinePageParams
@@ -264,8 +276,8 @@ describe('Utils', function () {
     expect(finalConfig.shareScreen.shareContent).toEqual(['social', 'embed', 'ooyala']);
 
     arrayFusion = 'prepend';
-    mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name'});
-    finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), unionBy:'name', arrayFusion:arrayFusion});
+    mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name'});
+    finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', arrayFusion:arrayFusion});
 
     // test array merge for buttons (prepend)
     expect(finalConfig.buttons.desktopContent.length).toBe(14);

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -2,6 +2,8 @@ jest.dontMock('../js/controller');
 jest.dontMock('screenfull');
 jest.dontMock('../js/constants/constants');
 jest.dontMock('../js/components/utils');
+jest.dontMock('../config/skin');
+jest.dontMock('deepmerge');
 
 var CONSTANTS = require('../js/constants/constants');
 
@@ -202,7 +204,8 @@ OO = {
       calculateAspectRatio: function(a,b) {},
       setAspectRatio: function() {window.isAspectRatioSet = true;},
       createPluginElements: function() {},
-      findMainVideoElement: function(a) {}
+      findMainVideoElement: function(a) {},
+      loadConfigData: function(a, b, c, d) {}
     };
 
 
@@ -218,7 +221,7 @@ OO = {
     videoElement.id = videoId;
     videoElement.preload = "none";
     videoElement.src = "http://cf.c.ooyala.com/RmZW4zcDo6KqkTIhn1LnowEZyUYn5Tb2/DOcJ-FxaFrRg4gtDEwOmY1OjA4MTtU7o?_=hihx01nww4iqldo893sor";
-
+    var persistentSettings = {"closedCaptionOptions":{"textColor":"Blue","backgroundColor":"Transparent","windowColor":"Yellow","windowOpacity":"0.3","fontType":"Proportional Serif","fontSize":"Medium","textEnhancement":"Shadow","enabled":true,"language":"unknown","backgroundOpacity":"0.2","textOpacity":"1"}};
     //setup document body for valid DOM elements
     document.body.innerHTML =
       '<div id='+elementId+'>' +
@@ -233,13 +236,14 @@ OO = {
     Html5Skin.externalPluginSubscription.call(controllerMock);
 
     //test player state
-    var tempSkin = $.extend(true, {}, controllerMock.skin);
-    Html5Skin.onPlayerCreated.call(controllerMock, 'customerUi', elementId, {skin:{config:{}}}, {});
-    Html5Skin.loadConfigData.call(controllerMock, {skin:{config:{}}}, {});
+    var tempSkin = controllerMock.skin;
+    Html5Skin.onPlayerCreated.call(controllerMock, 'customerUi', elementId, {skin:{config:{}}}, persistentSettings);
+    Html5Skin.onSkinMetaDataFetched.call(controllerMock, 'customerUi', {});
+    Html5Skin.loadConfigData.call(controllerMock, 'customerUi', {skin:{config:{}}}, {}, {}, {});
     Html5Skin.createPluginElements.call(controllerMock);
     controllerMock.skin = tempSkin; //reset skin, onPlayerCreated updates skin
 
-    var tempMainVideoElement = $.extend(true, {}, controllerMock.state.mainVideoElement);
+    var tempMainVideoElement = controllerMock.state.mainVideoElement;
     Html5Skin.onVcVideoElementCreated.call(controllerMock, 'customerUi', {videoId: OO.VIDEO.MAIN, videoElement: videoElement});
     controllerMock.state.mainVideoElement = tempMainVideoElement;
 


### PR DESCRIPTION
* we are using this [deep merge lib](https://github.com/KyleAMathews/deepmerge/blob/master/index.js#L64)
* the custom `arrayDeepMerge` function is passed as a callback to deepmerge function and only used if there is an array in the object that needs to be merged
* Also see - https://github.com/KyleAMathews/deepmerge#arraymerge
* controller updated to subscribe to `OO.EVENTS.SKIN_METADATA_FETCHED` event, returns v3 metadata, deep merges with `skin.json`
* `arrayDeepMerge` function updated to replace buttons by default, prepend after flexible space is also another option
* buttons disabled if `location: "none"`
* `swap` no longer used but still an optional param