### PR TITLE
[PLAYER-212] - Showing Discovery countdown after exiting fullscreen on iOS

### DIFF
--- a/js/components/discoveryPanel.js
+++ b/js/components/discoveryPanel.js
@@ -17,7 +17,7 @@ var DiscoveryPanel = React.createClass({
 
   getInitialState: function() {
     return {
-      showDiscoveryCountDown: this.props.skinConfig.discoveryScreen.showCountDownTimerOnEndScreen,
+      showDiscoveryCountDown: this.props.skinConfig.discoveryScreen.showCountDownTimerOnEndScreen || this.props.forceCountDownTimer,
       currentPage: 1,
       componentHeight: null
     };

--- a/js/controller.js
+++ b/js/controller.js
@@ -282,6 +282,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.state.videoQualityOptions.availableBitrates = null;
       this.state.videoQualityOptions.selectedBitrate = null;
       this.state.closedCaptionOptions.availableLanguages = null;
+      this.state.closedCaptionOptions.cueText = null;
       this.state.closedCaptionsInfoCache = {};
       this.state.discoveryData = null;
       this.state.thumbnails = null;

--- a/js/controller.js
+++ b/js/controller.js
@@ -40,6 +40,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       "screenToShow": null,
       "playerState": null,
       "discoveryData": null,
+      "forceCountDownTimerOnEndScreen": false,
       "isPlayingAd": false,
       "adOverlayUrl": null,
       "showAdOverlay": false,
@@ -990,6 +991,19 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     // iOS event fires when a video exits full-screen mode
     webkitEndFullscreen: function() {
       this.state.fullscreen = false;
+      var showUpNext = this.skin.props.skinConfig.upNext.showUpNext || this.skin.props.skinConfig.discoveryScreen.showCountDownTimerOnEndScreen;
+
+      // [PLAYER-212]
+      // We can't show UI such as the "Up Next" countdown on fullscreen iOS. If a countdown
+      // is configured, we wait until the user exits fullscreen and then we display it.
+      if (showUpNext && this.state.playerState === CONSTANTS.STATE.END) {
+        this.state.forceCountDownTimerOnEndScreen = true;
+        this.sendDiscoveryDisplayEvent("endScreen");
+        this.state.pluginsElement.addClass("oo-overlay-blur");
+        this.state.screenToShow = CONSTANTS.SCREEN.DISCOVERY_SCREEN;
+        this.renderSkin();
+        this.state.forceCountDownTimerOnEndScreen = false;
+      }
     },
 
     // exit full window on ESC key

--- a/js/skin.js
+++ b/js/skin.js
@@ -199,6 +199,7 @@ var Skin = React.createClass({
               <DiscoveryPanel
                 {...this.props}
                 videosPerPage={{xs:2, sm:4, md:6, lg:8}}
+                forceCountDownTimer={this.state.forceCountDownTimerOnEndScreen}
                 discoveryData={this.state.discoveryData}
                 playerState={this.state.playerState}
                 responsiveView={this.state.responsiveId}


### PR DESCRIPTION
[Link to ticket](https://jira.corp.ooyala.com/browse/PLAYER-212)

These changes are meant to mimic the way V3 handles autoplay for Discovery videos on iOS. Since we can't show the *Up Next Panel* on fullscreen, we wait until the user exits fullscreen and then we display the countdown. The discovery screen's counter will be used if either `upNext.showUpNext` or `discoveryScreen.showCountDownTimerOnEndScreen` are configured.

This should be merged along with these other PR's:
https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/16
https://github.com/ooyala/html5-video-plugins/pull/258