### PR TITLE
[PLAYER-20] fixes problem with social content arrays from backlot not…

### DIFF
--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -436,14 +436,21 @@ var Utils = {
    *        arrayMerge - https://github.com/KyleAMathews/deepmerge#arraymerge
    *        clone - https://github.com/KyleAMathews/deepmerge#clone
    *        arrayUnionBy - key used to compare Objects being merged, i.e. button name
-   *        arrayFusion - method used to merge arrays ['replace', 'prepend']
+   *        arrayFusion - method used to merge arrays ['replace', 'deepmerge']
+   *        buttonArrayFusion - method used to merge button array ['replace', 'prepend', 'deepmerge']
    *        arraySwap - swaps target/source
    * @returns {Array} new merged array with items from both target and source
    */
   arrayDeepMerge: function(target, source, optionsArgument) {
-    // returns source, no merge
-    if (optionsArgument.arrayFusion === 'replace') {
-      return source;
+    if (source && source.length) {
+      // if source is button and buttonArrayFusion is 'replace', return source w/o merge
+      if (source[0][optionsArgument.arrayUnionBy] && optionsArgument.buttonArrayFusion === 'replace') {
+        return source;
+      }
+      // if source is not button and arrayFusion is 'replace', return source w/o merge
+      else if (!source[0][optionsArgument.arrayUnionBy] && optionsArgument.arrayFusion !== 'deepmerge') {
+        return source;
+      }
     }
 
     var targetArray = optionsArgument.arraySwap ? source : target;
@@ -467,7 +474,7 @@ var Utils = {
               destination[j] = DeepMerge(targetObject, sourceObject, optionsArgument);
 
               // prunes uniqueSourceArray to unique items not in target
-              if (optionsArgument.arrayFusion === 'prepend' && uniqueSourceArray && uniqueSourceArray.length) {
+              if (optionsArgument.buttonArrayFusion === 'prepend' && uniqueSourceArray && uniqueSourceArray.length) {
                 for (var x in uniqueSourceArray) {
                   if (uniqueSourceArray[x][optionsArgument.arrayUnionBy] === sourceItem[optionsArgument.arrayUnionBy]) {
                     uniqueSourceArray.splice(x, 1);
@@ -488,7 +495,7 @@ var Utils = {
       }
     });
     // prepend uniqueSourceArray array of unique items to buttons after flexible space
-    if (optionsArgument.arrayFusion === 'prepend' && uniqueSourceArray && uniqueSourceArray.length) {
+    if (optionsArgument.buttonArrayFusion === 'prepend' && uniqueSourceArray && uniqueSourceArray.length) {
       var flexibleSpaceIndex = null;
       // find flexibleSpace btn index
       for (var y in destination) {

--- a/js/controller.js
+++ b/js/controller.js
@@ -798,12 +798,34 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       var inlinePageParams = Utils.getPropertyValue(params, 'skin.inline') ? params.skin.inline : {};
       var customSkinJSON = data ? data : {};
       var metaDataSettings = skinMetaData ? skinMetaData : {};
+
+      //to make sure backlot metadata for shareContent and socialContent arrays has higher priority than embedded skin config
+      var backlotShareContent = Utils.getPropertyValue(skinMetaData, 'shareScreen.shareContent');
+      var backlotSocialContent = Utils.getPropertyValue(skinMetaData, 'shareScreen.socialContent');
+      if (backlotShareContent) {
+        SkinJSON.shareScreen.shareContent = backlotShareContent;
+      }
+      if (backlotSocialContent) {
+        SkinJSON.shareScreen.socialContent = backlotSocialContent;
+      }
+
       var arrayFusion = params.buttonMerge ? params.buttonMerge : 'replace';
 
       //override data in skin config with possible local storage settings, inline data input by user, and CMS settings in backlot/themebuilder
       var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name'});
       this.state.config = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', arrayFusion:arrayFusion});
       this.state.closedCaptionOptions = this.state.config.closedCaptionOptions;
+
+      //remove 'url' from the list until the tab is worked on
+      var shareContent = Utils.getPropertyValue(this.state.config, 'shareScreen.shareContent');
+      if (shareContent) {
+        for (var i = 0; i < shareContent.length; i++) {
+          if (shareContent[i] == 'url') {
+            shareContent.splice(i, 1);
+          }
+        }
+        this.state.config.shareScreen.shareContent = shareContent;
+      }
 
       //load config language json if exist
       if (this.state.config.localization.availableLanguageFile) {

--- a/js/controller.js
+++ b/js/controller.js
@@ -798,11 +798,11 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       var inlinePageParams = Utils.getPropertyValue(params, 'skin.inline') ? params.skin.inline : {};
       var customSkinJSON = data ? data : {};
       var metaDataSettings = skinMetaData ? skinMetaData : {};
-      var arrayFusion = params.buttonMerge ? params.buttonMerge : 'replace';
+      var buttonArrayFusion = params.buttonMerge ? params.buttonMerge : 'replace';
 
       //override data in skin config with possible local storage settings, inline data input by user, and CMS settings in backlot/themebuilder
       var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name'});
-      this.state.config = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', arrayFusion:arrayFusion});
+      this.state.config = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', buttonArrayFusion:buttonArrayFusion});
       this.state.closedCaptionOptions = this.state.config.closedCaptionOptions;
 
       //remove 'url' from the list until the tab is worked on

--- a/js/controller.js
+++ b/js/controller.js
@@ -798,17 +798,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       var inlinePageParams = Utils.getPropertyValue(params, 'skin.inline') ? params.skin.inline : {};
       var customSkinJSON = data ? data : {};
       var metaDataSettings = skinMetaData ? skinMetaData : {};
-
-      //to make sure backlot metadata for shareContent and socialContent arrays has higher priority than embedded skin config
-      var backlotShareContent = Utils.getPropertyValue(skinMetaData, 'shareScreen.shareContent');
-      var backlotSocialContent = Utils.getPropertyValue(skinMetaData, 'shareScreen.socialContent');
-      if (backlotShareContent) {
-        SkinJSON.shareScreen.shareContent = backlotShareContent;
-      }
-      if (backlotSocialContent) {
-        SkinJSON.shareScreen.socialContent = backlotSocialContent;
-      }
-
       var arrayFusion = params.buttonMerge ? params.buttonMerge : 'replace';
 
       //override data in skin config with possible local storage settings, inline data input by user, and CMS settings in backlot/themebuilder

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -254,10 +254,10 @@ describe('Utils', function () {
       "closedCaptionOptions":{"fontSize":"Large","windowColor":"Green"},
       "buttons":{"desktopContent":[{"name":"share","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":45,"enabled":true},{"name":"volume","location":"controlBar","whenDoesNotFit":"keep","minWidth":45,"enabled":true},{"name":"fullscreen","location":"controlBar","whenDoesNotFit":"keep","minWidth":55,"enabled":true},{"name":"quality","location":"controlBar","whenDoesNotFit":"moveToMoreOptions","minWidth":45,"enabled":true}]},"general":{"accentColor":"#ffbb00","watermark":{"imageResource":{"url":"http://ak.c.ooyala.com/Uzbm46asiensk3opIgwfFn5KFemv/watermark147585568"},"position":"top-left","clickUrl":"","transparency":0.51,"scalingOption":"none","scalingPercentage":0}},"shareScreen":{"shareContent":["social","ooyala"],"socialContent":["twitter","lisa","google+","jason"]}
     };
-    var arrayFusion = 'replace';
+    var buttonArrayFusion = 'replace';
 
-    var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name'});
-    var finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', arrayFusion:arrayFusion});
+    var mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', arrayFusion:'deepmerge'});
+    var finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', arrayFusion:'deepmerge', buttonArrayFusion:buttonArrayFusion});
 
     // test merge hierarchy, keys from 5 objects should be merged into one object with correct priority
     expect(finalConfig.closedCaptionOptions.textColor).toBe("Blue"); //from inlinePageParams
@@ -275,10 +275,13 @@ describe('Utils', function () {
     expect(finalConfig.shareScreen.shareContent[2]).toBe(metaDataSettings.shareScreen.shareContent[1]);
     expect(finalConfig.shareScreen.shareContent).toEqual(['social', 'embed', 'ooyala']);
 
-    arrayFusion = 'prepend';
+    buttonArrayFusion = 'prepend';
     mergedMetaData = DeepMerge(SkinJSON, metaDataSettings, {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name'});
-    finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', arrayFusion:arrayFusion});
+    finalConfig = DeepMerge.all([mergedMetaData, customSkinJSON, inlinePageParams, localSettings], {arrayMerge: Utils.arrayDeepMerge.bind(Utils), arrayUnionBy:'name', buttonArrayFusion:buttonArrayFusion});
 
+    // test basic array replace
+    expect(finalConfig.shareScreen.shareContent[1]).not.toBe(SkinJSON.shareScreen.shareContent[1]);
+    expect(finalConfig.shareScreen.shareContent).toEqual(['social', 'ooyala']);
     // test array merge for buttons (prepend)
     expect(finalConfig.buttons.desktopContent.length).toBe(14);
     // test new buttons are placed after flexibleSpace


### PR DESCRIPTION
… respected; removing `url` content since we don`t have the tab

There are two changes, one makes sure that if embedded skin config has shareScreen.shareContent == ['social', 'embed'], but the backlot has only shareScreen.shareContent == ['social'], the result is the backlot array, not the embedded.

The second change is for removing the 'url' from the list of shareContent values. As I understand, we might use it later, but now share screen can't handle it.