### PR TITLE
[PBW-6348] - Disabling pointer cursor on non-clickable time display

### DIFF
--- a/scss/components/_control-bar.scss
+++ b/scss/components/_control-bar.scss
@@ -86,6 +86,8 @@
       text-align: left;
       position: relative;
       top:-2px;
+      cursor: auto;
+      @include vendor-prefixes(user-select, text);
 
       .oo-total-time {
         color: $white;


### PR DESCRIPTION
[Ticket](https://jira.corp.ooyala.com/browse/PBW-6348)

Since the time display isn't clickable, a customer suggested that we shouldn't display a pointer cursor over it.