### PR TITLE
[PLAYER-329] - Triggering RELATED_VIDEOS_DISPLAYED event when Up Next panel is shown

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -435,7 +435,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         // Trigger discovery event only the first time we
         // switch from hidden to showing
         if (!this.state.upNextInfo.showing) {
-          this.sendDiscoveryDisplayEvent(CONSTANTS.SCREEN.PLAYING_SCREEN);
+          this.sendDiscoveryDisplayEvent("endScreen");
         }
         this.state.upNextInfo.showing = true;
       }

--- a/js/controller.js
+++ b/js/controller.js
@@ -435,7 +435,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         // Trigger discovery event only the first time we
         // switch from hidden to showing
         if (!this.state.upNextInfo.showing) {
-          this.sendDiscoveryDisplayEvent("endScreen");
+          var upNextEmbedCode = Utils.getPropertyValue(this.state.upNextInfo, "upNextData.embed_code");
+          this.sendDiscoveryDisplayEvent("endScreen", upNextEmbedCode);
         }
         this.state.upNextInfo.showing = true;
       }
@@ -1303,10 +1304,22 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       }
     },
 
-    sendDiscoveryDisplayEvent: function(screen) {
+    sendDiscoveryDisplayEvent: function(screenName, embedCode) {
+      var relatedVideosData = Utils.getPropertyValue(this.state.discoveryData, "relatedVideos", []);
+      var relatedVideos = relatedVideosData;
+
+      // With "Up Next" panel we only pass the data of the asset
+      // that is currently shown
+      if (embedCode) {
+        var eventAsset = _.find(relatedVideosData, function(relatedVideo) {
+          return relatedVideo.embed_code === embedCode;
+        });
+        relatedVideos = eventAsset ? [eventAsset] : [];
+      }
+
       var eventData = {
-        "relatedVideos" : this.state.discoveryData.relatedVideos,
-        "custom" : { "source" : screen}
+        "relatedVideos" : relatedVideos,
+        "custom" : { "source" : screenName }
       };
       this.mb.publish(OO.EVENTS.DISCOVERY_API.SEND_DISPLAY_EVENT, eventData);
     },

--- a/js/controller.js
+++ b/js/controller.js
@@ -1288,6 +1288,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.state.upNextInfo.delayedSetEmbedCodeEvent = true;
       }
       else {
+        this.state.upNextInfo.showing = false;
         this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
         this.renderSkin();
         this.mb.publish(OO.EVENTS.PAUSE);

--- a/js/controller.js
+++ b/js/controller.js
@@ -432,6 +432,11 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         !this.state.upNextInfo.countDownCancelled &&
         this.state.isPlayingAd !== true &&
         this.state.upNextInfo.upNextData !== null && (this.state.playerState === CONSTANTS.STATE.PLAYING || this.state.playerState === CONSTANTS.STATE.PAUSE)) {
+        // Trigger discovery event only the first time we
+        // switch from hidden to showing
+        if (!this.state.upNextInfo.showing) {
+          this.sendDiscoveryDisplayEvent(CONSTANTS.SCREEN.PLAYING_SCREEN);
+        }
         this.state.upNextInfo.showing = true;
       }
       else {
@@ -536,6 +541,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         }
 
         this.mb.publish(OO.EVENTS.DISCOVERY_API.SEND_CLICK_EVENT, delayedContentData);
+        this.state.upNextInfo.showing = false;
         this.state.upNextInfo.delayedSetEmbedCodeEvent = false;
         this.state.upNextInfo.delayedContentData = null;
       }
@@ -1277,7 +1283,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
 
     sendDiscoveryClickEvent: function(selectedContentData, isAutoUpNext) {
       this.state.pluginsElement.removeClass("oo-overlay-blur");
-      this.state.upNextInfo.showing = false;
       if (isAutoUpNext){
         this.state.upNextInfo.delayedContentData = selectedContentData;
         this.state.upNextInfo.delayedSetEmbedCodeEvent = true;


### PR DESCRIPTION
[Ticket](https://jira.corp.ooyala.com/browse/PLAYER-329)

The analytics backend requires that a `Related Videos Displayed` event be fired before a `Related Video Selected`, otherwise the latter event will be discarded. On V4 `Related Videos Displayed` was only getting fired when the Discovery screen was shown, which means that all the Discovery related data was getting lost if the _Up Next_ panel was used.

These changes trigger a `Related Videos Displayed` event when the _Up Next_ panel is first shown.