### PR TITLE
[PLAYER-423] moving moving externalPluginSubscription to earlier

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -139,7 +139,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       "isFullWindow": false,
       "autoPauseDisabled": false
     };
-
     this.init();
   };
 
@@ -207,6 +206,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
           this.mb.subscribe(OO.EVENTS.SHOW_AD_MARQUEE, "customerUi", _.bind(this.onShowAdMarquee, this));
         }
       }
+
       this.state.isSubscribed = true;
     },
 
@@ -220,6 +220,9 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
      event listeners from core player -> regulate skin STATE
      ---------------------------------------------------------------------*/
     onPlayerCreated: function (event, elementId, params, settings) {
+      //subscribe to plugin events
+      this.externalPluginSubscription();
+
       //set state variables
       this.state.mainVideoContainer = $("#" + elementId);
       this.state.mainVideoInnerWrapper = $("#" + elementId + " .innerWrapper");
@@ -890,7 +893,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         videoWrapperClass: "innerWrapper",
         pluginsClass: "oo-player-skin-plugins"
       });
-      this.externalPluginSubscription();
     },
 
     onBitrateInfoAvailable: function(event, bitrates) {

--- a/js/controller.js
+++ b/js/controller.js
@@ -139,6 +139,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       "isFullWindow": false,
       "autoPauseDisabled": false
     };
+
     this.init();
   };
 
@@ -206,7 +207,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
           this.mb.subscribe(OO.EVENTS.SHOW_AD_MARQUEE, "customerUi", _.bind(this.onShowAdMarquee, this));
         }
       }
-
       this.state.isSubscribed = true;
     },
 


### PR DESCRIPTION
The timing of subscribing to OO.EVENTS.DISCOVERY_API.RELATED_VIDEOS_FETCHED was too late, sometimes we were subscribing *after* the even was fired. Hence, the discovery was not usable.

I am moving the subscription up, to the earliest point where discovery plugin is already loaded.

[PLAYER-423](https://jira.corp.ooyala.com/browse/PLAYER-423)