### PR TITLE
Make sure player destroy removes attached keyboard eventlisteners

### DIFF
--- a/js/components/accessibilityControls.js
+++ b/js/components/accessibilityControls.js
@@ -6,10 +6,16 @@ var AccessibilityControls = function (controller) {
       "fastForwardRate": 1,
       "lastKeyDownTime": null
     };
-    document.addEventListener("keydown", this.handleKey.bind(this));
+
+    this.keyEvent = this.handleKey.bind(this);
+    document.addEventListener("keydown", this.keyEvent);
 };
 
 AccessibilityControls.prototype = {
+  cleanUp : function() {
+    document.removeEventListener("keydown", this.keyEvent);
+  },
+
   handleKey: function(e) {
     if (!this.controller.state.accessibilityControlsEnabled){
       return;

--- a/js/controller.js
+++ b/js/controller.js
@@ -247,7 +247,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.loadConfigData(this.state.playerParam, this.state.persistentSettings, this.state.customSkinJSON, this.state.skinMetaData);
       }
 
-      var accessibilityControls = new AccessibilityControls(this); //keyboard support
+      this.accessibilityControls = new AccessibilityControls(this); //keyboard support
       this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
     },
 
@@ -283,7 +283,12 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       if (mountNode) {
         ReactDOM.unmountComponentAtNode(mountNode);
       }
+      this.cleanUpEventListeners()
       this.mb = null;
+    },
+
+    cleanUpEventListeners : function() {
+      this.accessibilityControls.cleanUp()
     },
 
     onEmbedCodeChangedAfterOoyalaAd: function(event, embedCode, options) {


### PR DESCRIPTION
Seems to be an issue when video returns an error on load. And the keyboard events will still be attached even if the player is unmounted. 