### PR TITLE
Properly remove event listener

### DIFF
--- a/js/mixins/responsiveManagerMixin.js
+++ b/js/mixins/responsiveManagerMixin.js
@@ -12,14 +12,15 @@ var ResponsiveManagerMixin = {
   },
 
   componentDidMount: function() {
-    window.addEventListener('resize', debounce(this.onResize, 150));
-    window.addEventListener('webkitfullscreenchange', debounce(this.onResize, 150));
+    this.debouncedResize = debounce(this.onResize, 150);
+    window.addEventListener('resize', this.debouncedResize);
+    window.addEventListener('webkitfullscreenchange', this.debouncedResize);
     this.generateResponsiveData();
   },
 
   componentWillUnmount: function() {
-    window.removeEventListener('resize', this.onResize);
-    window.removeEventListener('webkitfullscreenchange', this.onResize);
+    window.removeEventListener('resize', this.debouncedResize);
+    window.removeEventListener('webkitfullscreenchange', this.debouncedResize);
   },
 
   onResize: function() {


### PR DESCRIPTION
When this component is unmounted in full-screen mode, ReactDOM will throw an error:

`findDOMNode was called on an unmounted component.`

This occurs because of improper cleanup on the unmount. This PR fixes that.