### PR TITLE
Don't show CC icon when it's disabled in the settings

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1421,8 +1421,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         return;
       }
       // Load the CC info for the video with the given id onto the state
-      this.state.closedCaptionOptions.availableLanguages = closedCaptionsInfo;
       if (this.state.closedCaptionOptions.enabled) {
+        this.state.closedCaptionOptions.availableLanguages = closedCaptionsInfo;
         this.setClosedCaptionsLanguage();
       }
     },


### PR DESCRIPTION
This way providers can prevent CC icon from always being displayed in Mac Safari.