### PR TITLE
[PLAYER-1257]  Hiding everything but thumbnail until PLAYBACK_READY

### DIFF
--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -11,6 +11,7 @@ module.exports = {
   },
 
   SCREEN: {
+    INITIAL_SCREEN: "initialScreen",
     START_SCREEN: "startScreen",
     PLAYING_SCREEN: "playingScreen",
     PAUSE_SCREEN: "pauseScreen",
@@ -24,10 +25,6 @@ module.exports = {
     CLOSEDCAPTION_SCREEN: "closedCaptionScreen",
     VIDEO_QUALITY_SCREEN: "videoQualityScreen",
     ERROR_SCREEN: "errorScreen"
-  },
-
-  CUSTOM_EVENTS: {
-    INITIAL_PLAY_REQUESTED: 'html5SkinInitialPlayRequested'
   },
 
   SKIN_TEXT: {

--- a/js/controller.js
+++ b/js/controller.js
@@ -164,9 +164,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.mb.subscribe(OO.EVENTS.ASSET_UPDATED, 'customerUi', _.bind(this.onAssetUpdated, this));
       this.mb.subscribe(OO.EVENTS.PLAYBACK_READY, 'customerUi', _.bind(this.onPlaybackReady, this));
       this.mb.subscribe(OO.EVENTS.ERROR, "customerUi", _.bind(this.onErrorEvent, this));
-      this.mb.subscribe(CONSTANTS.CUSTOM_EVENTS.INITIAL_PLAY_REQUESTED, "customerUi", _.bind(this.onInitialPlayRequested, this));
       this.mb.addDependent(OO.EVENTS.PLAYBACK_READY, OO.EVENTS.UI_READY);
-      this.mb.addDependent(CONSTANTS.CUSTOM_EVENTS.INITIAL_PLAY_REQUESTED, OO.EVENTS.PLAYBACK_READY);
       this.state.isPlaybackReadySubscribed = true;
     },
 
@@ -260,7 +258,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       }
 
       this.accessibilityControls = new AccessibilityControls(this); //keyboard support
-      this.state.screenToShow = CONSTANTS.SCREEN.START_SCREEN;
+      this.state.screenToShow = CONSTANTS.SCREEN.INITIAL_SCREEN;
     },
 
     onVcVideoElementCreated: function(event, params) {
@@ -669,17 +667,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.state.mainVideoAspectRatio = this.calculateAspectRatio(params.width, params.height);
         this.setAspectRatio();
       }
-    },
-
-    /**
-     * Handles the custom INITIAL_PLAY_REQUESTED skin event. This event is used in
-     * order to defer INITIAL_PLAY until PLAYBACK_READY has been fired. Doing this allows
-     * us to display the big play button before the player finishes loading. If the user
-     * clicks on the button before PLAYBACK_READY, the player will simply show the loading
-     * spinner and INITIAL_PLAY will be automatically fired after PLAYBACK_READY itself fires.
-     */
-    onInitialPlayRequested: function() {
-      this.mb.publish(OO.EVENTS.INITIAL_PLAY, Date.now());
     },
 
     /********************************************************************
@@ -1132,8 +1119,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.mb.unsubscribe(OO.EVENTS.PLAYBACK_READY, 'customerUi');
       this.mb.unsubscribe(OO.EVENTS.ERROR, "customerUi");
       this.mb.unsubscribe(OO.EVENTS.SET_EMBED_CODE_AFTER_OOYALA_AD, 'customerUi');
-      // custom skin events
-      this.mb.unsubscribe(CONSTANTS.CUSTOM_EVENTS.INITIAL_PLAY_REQUESTED, "customerUi");
     },
 
     unsubscribeBasicPlaybackEvents: function() {
@@ -1241,7 +1226,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     togglePlayPause: function() {
       switch (this.state.playerState) {
         case CONSTANTS.STATE.START:
-          this.mb.publish(CONSTANTS.CUSTOM_EVENTS.INITIAL_PLAY_REQUESTED);
+          this.mb.publish(OO.EVENTS.INITIAL_PLAY, Date.now());
           break;
         case CONSTANTS.STATE.END:
           if(Utils.isAndroid() || Utils.isIos()) {

--- a/js/skin.js
+++ b/js/skin.js
@@ -87,6 +87,14 @@ var Skin = React.createClass({
     //switch screenToShow
     else {
       switch (this.state.screenToShow) {
+        case CONSTANTS.SCREEN.INITIAL_SCREEN:
+          screen = (
+            <StartScreen {...this.props}
+              componentWidth={this.state.componentWidth}
+              contentTree={this.state.contentTree}
+              isInitializing={true} />
+          );
+          break;
         case CONSTANTS.SCREEN.LOADING_SCREEN:
           screen = (
             <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url}/>
@@ -96,7 +104,8 @@ var Skin = React.createClass({
           screen = (
             <StartScreen {...this.props}
               componentWidth={this.state.componentWidth}
-              contentTree={this.state.contentTree} />
+              contentTree={this.state.contentTree}
+              isInitializing={false} />
           );
           break;
         case CONSTANTS.SCREEN.PLAYING_SCREEN:

--- a/js/views/startScreen.js
+++ b/js/views/startScreen.js
@@ -41,10 +41,14 @@ var StartScreen = React.createClass({
   },
 
   handleClick: function(event) {
-    event.preventDefault();
-    this.props.controller.togglePlayPause();
-    this.props.controller.state.accessibilityControlsEnabled = true;
-    this.setState({playButtonClicked: true});
+    // Avoid starting playback when player is initializing (play button is disabled
+    // in this state, but you can still click on the thumbnail)
+    if (!this.props.isInitializing) {
+      event.preventDefault();
+      this.props.controller.togglePlayPause();
+      this.props.controller.state.accessibilityControlsEnabled = true;
+      this.setState({playButtonClicked: true});
+    }
   },
 
   render: function() {
@@ -97,16 +101,33 @@ var StartScreen = React.createClass({
 
     var titleMetadata = (<div className={titleClass} style={titleStyle}>{this.props.contentTree.title}</div>);
     var iconName = (this.props.controller.state.playerState == CONSTANTS.STATE.END ? "replay" : "play");
-    var descriptionMetadata = (<div className={descriptionClass} ref="description" style={descriptionStyle}>{this.state.descriptionText}</div>);
-
-    var actionIcon = (
-      <button className={actionIconClass}
-        onClick={this.handleClick}
-        tabIndex="0"
-        aria-label={CONSTANTS.ARIA_LABELS.START_PLAYBACK}>
-        <Icon {...this.props} icon={iconName} style={actionIconStyle}/>
-      </button>
+    // The descriptionText value doesn't react to changes in contentTree.description since
+    // it's being handled as internal state in order to allow truncating it on player resize.
+    // We need to migrate truncateTextToWidth to a CSS solution in order to avoid this.
+    var descriptionMetadata = (
+      <div className={descriptionClass} ref="description" style={descriptionStyle}>
+        {this.state.descriptionText || this.props.contentTree.description}
+      </div>
     );
+
+    var actionIcon, infoPanel;
+    // We do not show the action icon, title or description when the player is initializing
+    if (!this.props.isInitializing) {
+      actionIcon = (
+        <button className={actionIconClass}
+          onClick={this.handleClick}
+          tabIndex="0"
+          aria-label={CONSTANTS.ARIA_LABELS.START_PLAYBACK}>
+          <Icon {...this.props} icon={iconName} style={actionIconStyle}/>
+        </button>
+      );
+      infoPanel = (
+        <div className={infoPanelClass}>
+          {this.props.skinConfig.startScreen.showTitle ? titleMetadata : null}
+          {this.props.skinConfig.startScreen.showDescription ? descriptionMetadata : null}
+        </div>
+      );
+    }
 
     return (
       <div className="oo-state-screen oo-start-screen">
@@ -115,11 +136,7 @@ var StartScreen = React.createClass({
           <a className="oo-state-screen-selectable" onClick={this.handleClick}></a>
         </div>
         <Watermark {...this.props} controlBarVisible={false}/>
-        <div className={infoPanelClass}>
-          {this.props.skinConfig.startScreen.showTitle ? titleMetadata : null}
-          {this.props.skinConfig.startScreen.showDescription ? descriptionMetadata : null}
-        </div>
-
+        {infoPanel}
         {(this.state.playButtonClicked && this.props.controller.state.playerState == CONSTANTS.STATE.START) || this.props.controller.state.buffering ?
           <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url}/> : actionIcon}
       </div>
@@ -128,6 +145,7 @@ var StartScreen = React.createClass({
 });
 
 StartScreen.propTypes = {
+  isInitializing: React.PropTypes.bool,
   skinConfig: React.PropTypes.shape({
     startScreen: React.PropTypes.shape({
       playIconStyle: React.PropTypes.shape({
@@ -139,6 +157,7 @@ StartScreen.propTypes = {
 };
 
 StartScreen.defaultProps = {
+  isInitializing: false,
   skinConfig: {
     general: {
       loadingImage: {

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -556,40 +556,12 @@ OO = {
     Html5Skin.findMainVideoElement.call(controllerMock, {0:videoElement});
 
     describe('Controller testing skin initialization', function() {
-      // TODO
-      // This gets cleared up below in the "destroy" tests due to the way this
-      // test suite is currently set up. We need a lot of refactoring to fix this,
-      // so we're working around it for now
-      var mb = controllerMock.mb;
-      var messageBusSpy;
 
-      beforeEach(function() {
-        controllerMock.mb = mb;
-        messageBusSpy = sinon.spy(controllerMock.mb, 'publish');
-      });
-
-      afterEach(function() {
-        messageBusSpy.restore();
-      });
-
-      it('should show Start Screen after player created', function() {
+      it('should show Initial Screen after player created', function() {
         Html5Skin.onPlayerCreated.call(controllerMock, 'customerUi', 'elementId', {});
-        expect(controllerMock.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
+        expect(controllerMock.state.screenToShow).toBe(CONSTANTS.SCREEN.INITIAL_SCREEN);
       });
-
-      it('should raise INITIAL_PLAY_REQUESTED event when toggling play/pause on Start Screen', function() {
-        Html5Skin.onPlayerCreated.call(controllerMock, 'customerUi', 'elementId', {});
-        Html5Skin.togglePlayPause.call(controllerMock);
-        expect(messageBusSpy.calledOnce).toBe(true);
-        expect(messageBusSpy.calledWith(CONSTANTS.CUSTOM_EVENTS.INITIAL_PLAY_REQUESTED)).toBe(true);
-      });
-
-      it('should publish INITIAL_PLAY after INITIAL_PLAY_REQUESTED', function() {
-        Html5Skin.onInitialPlayRequested.call(controllerMock);
-        expect(messageBusSpy.calledOnce).toBe(true);
-        expect(messageBusSpy.args.length).toBe(1);
-        expect(messageBusSpy.calledWith(OO.EVENTS.INITIAL_PLAY)).toBe(true);
-      });
+      
     });
 
     describe('Controller testing Ooyala Ads', function () {

--- a/tests/views/startScreen-test.js
+++ b/tests/views/startScreen-test.js
@@ -1,13 +1,48 @@
 jest.dontMock('../../js/views/startScreen')
-  .dontMock('../../js/components/icon');
+    .dontMock('../../js/components/utils')
+    .dontMock('../../js/components/icon')
+    .dontMock('../../js/constants/constants')
+    .dontMock('classnames');
 
 var React = require('react');
 var TestUtils = require('react-addons-test-utils');
 var StartScreen = require('../../js/views/startScreen');
+var skinConfig = require('../../config/skin.json');
 
 describe('StartScreen', function () {
-  it('test start screen', function () {
+  var mockController, mockProps;
 
+  beforeEach(function() {
+    mockController = {
+      state: {
+        contentTree: {
+          promo_image: 'image.png',
+          description: 'description',
+          title: 'title'
+        }
+      }
+    };
+    mockProps = {
+      controller: mockController,
+      skinConfig: JSON.parse(JSON.stringify(skinConfig))
+    };
+    mockProps.skinConfig.startScreen = {
+      titleFont: {},
+      descriptionFont: {},
+      playIconStyle: {
+        color: 'white'
+      },
+      infoPanelPosition: 'topLeft',
+      playButtonPosition: 'center',
+      showPlayButton: true,
+      showPromo: true,
+      showTitle: true,
+      showDescription: true,
+      promoImageSize: 'default'
+    };
+  });
+
+  it('should render start screen', function () {
     // Render start screen into DOM
     var DOM = TestUtils.renderIntoDocument(<StartScreen />);
 
@@ -15,4 +50,71 @@ describe('StartScreen', function () {
     var playBtn = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-state-screen-selectable');
     TestUtils.Simulate.click(playBtn);
   });
+
+  it('should render action icon when player is not initializing', function() {
+    var DOM = TestUtils.renderIntoDocument(
+      <StartScreen
+        {...mockProps}
+        contentTree={mockController.state.contentTree}
+        isInitializing={false} />
+    );
+    var actionIcon = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-action-icon');
+    expect(actionIcon).toBeDefined();
+  });
+
+  it('should NOT render action icon when player is initializing', function() {
+    var DOM = TestUtils.renderIntoDocument(
+      <StartScreen
+        {...mockProps}
+        contentTree={mockController.state.contentTree}
+        isInitializing={true} />
+    );
+    var actionIcons = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-action-icon');
+    expect(actionIcons.length).toBe(0);
+  });
+
+  it('should render info panel when player is not initializing', function() {
+    var DOM = TestUtils.renderIntoDocument(
+      <StartScreen
+        {...mockProps}
+        contentTree={mockController.state.contentTree}
+        isInitializing={false} />
+    );
+    var infoPanel = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-state-screen-info');
+    expect(infoPanel).toBeDefined();
+    var titleLabel = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-state-screen-title');
+    var descriptionLabel = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-state-screen-description');
+    expect(titleLabel.innerHTML).toEqual(mockController.state.contentTree.title);
+    expect(descriptionLabel.innerHTML).toEqual(mockController.state.contentTree.description);
+  });
+
+  it('should NOT render info panel when player is initializing', function() {
+    var DOM = TestUtils.renderIntoDocument(
+      <StartScreen
+        {...mockProps}
+        contentTree={mockController.state.contentTree}
+        isInitializing={true} />
+    );
+    var infoPanels = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-state-screen-info');
+    expect(infoPanels.length).toBe(0);
+  });
+
+  it('should react to title and description skin.json changes', function() {
+    mockProps.skinConfig.startScreen.showTitle = false;
+    mockProps.skinConfig.startScreen.showDescription = false;
+
+    var DOM = TestUtils.renderIntoDocument(
+      <StartScreen
+        {...mockProps}
+        contentTree={mockController.state.contentTree}
+        isInitializing={false} />
+    );
+    var infoPanel = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-state-screen-info');
+    expect(infoPanel).toBeDefined();
+    var titleLabels = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-state-screen-title');
+    var descriptionLabels = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-state-screen-description');
+    expect(titleLabels.length).toBe(0);
+    expect(descriptionLabels.length).toEqual(0);
+  });
+
 });


### PR DESCRIPTION
We will still be removing the spinner during startup, but instead of allowing the user to click on Play before `PLAYBACK_READY`, we will only show the thumbnail until the player is ready to play.