### PR TITLE
PLAYER-1487 fix

### DIFF
--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -71,7 +71,7 @@ var PlayingScreen = React.createClass({
 
   handleKeyPress: function(event) {
     // show control bar on tab key navigation
-    if (event.which === 9 || event.keyCode === 9) {
+    if ((event.which === 9 || event.keyCode === 9) || (event.which === 32 || event.keyCode === 32) || (event.which === 13 || event.keyCode === 13)) {
       this.showControlBar();
       this.props.controller.startHideControlBarTimer();
     }

--- a/tests/views/playingScreen-test.js
+++ b/tests/views/playingScreen-test.js
@@ -133,6 +133,51 @@ describe('PlayingScreen', function () {
     expect(autoHide && controlBar).toBe(true);
   });
 
+  it('should show control bar when pressing the tab, space bar or enter key', function () {
+    var autoHide = false;
+    var controlBar = false;
+
+    var mockController = {
+      state: {
+        isMobile: false,
+        accessibilityControlsEnabled: false,
+        upNextInfo: {
+          showing: false
+        }
+      },
+      startHideControlBarTimer: function() {autoHide = true},     
+      showControlBar: function() {controlBar = true}
+    };
+    
+    var closedCaptionOptions = {
+      cueText: "cue text"
+    };
+
+    var DOM = TestUtils.renderIntoDocument(<PlayingScreen  controller = {mockController} closedCaptionOptions = {closedCaptionOptions}/>);
+    var screen = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-playing-screen');
+
+    TestUtils.Simulate.keyUp(screen, {key: 'Tab', which: 9, keyCode: 9});
+    expect(autoHide && controlBar).toBe(true);
+
+    autoHide = false;
+    controlBar = false;
+
+    TestUtils.Simulate.keyUp(screen, {key: 'Enter', which: 13, keyCode: 13});
+    expect(autoHide && controlBar).toBe(true);
+
+    autoHide = false;
+    controlBar = false;
+
+    TestUtils.Simulate.keyUp(screen, {key: '', which: 32, keyCode: 32});
+    expect(autoHide && controlBar).toBe(true);
+
+    autoHide = false;
+    controlBar = false;
+
+    TestUtils.Simulate.keyUp(screen, {key: '', which: 16, keyCode: 16});
+    expect(autoHide && controlBar).toBe(false);
+  });
+
   it('tests playing screen componentWill*', function () {
     var mockController = {
       state: {


### PR DESCRIPTION
control bar now is shown hitting the space bar or the enter key into focusable buttons, unit tests added.
more information into the ticket PLAYER-1487 (https://jira.corp.ooyala.com:8443/browse/PLAYER-1487)