### PR TITLE
[PLAYER-1598] [PLAYER-1698] Unit tests + Restricting tab navigation on fullscreen

### DIFF
--- a/js/components/accessibilityControls.js
+++ b/js/components/accessibilityControls.js
@@ -90,7 +90,7 @@ AccessibilityControls.prototype = {
   /**
    * Determines whether or not the controller is in a state that allows seeking the video.
    * @private
-   * @return {Boolen} True if seeking is possible, false otherwise.
+   * @return {Boolean} True if seeking is possible, false otherwise.
    */
   canSeek: function() {
     var seekingEnabled = false;

--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -224,15 +224,17 @@ var ControlBar = React.createClass({
   /**
    * Will handle the keydown event when the controlBar is active and it will restrict
    * tab navigation to elements that are within it when the player is in fullscreen mode.
+   * Note that this only handles the edge cases that are needed in order to loop the tab
+   * focus. Tabbing in between the elements is handled by the browser.
    * @private
    * @param {Object} evt Keydown event object.
    */
   handleControlBarKeyDown: function(evt) {
     if (
-      evt.key !== CONSTANTS.KEY_VALUES.TAB
-      || !this.props.controller.state.fullscreen
-      || !this.domNode
-      || !evt.target
+      evt.key !== CONSTANTS.KEY_VALUES.TAB ||
+      !this.props.controller.state.fullscreen ||
+      !this.domNode ||
+      !evt.target
     ) {
       return;
     }
@@ -268,6 +270,8 @@ var ControlBar = React.createClass({
           firstFocusableElement.focus();
         }
       }
+    } else {
+      OO.log('ControlBar: No focusable elements found');
     }
   },
 

--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -27,6 +27,7 @@ var ControlBar = React.createClass({
 
   componentDidMount: function () {
     window.addEventListener('orientationchange', this.closePopovers);
+    document.addEventListener('keydown', this.handleControlBarKeyDown);
     this.restoreFocusedControl();
   },
 
@@ -44,6 +45,7 @@ var ControlBar = React.createClass({
       this.props.controller.hideVolumeSliderBar();
     }
     window.removeEventListener('orientationchange', this.closePopovers);
+    document.removeEventListener('keydown', this.handleControlBarKeyDown);
   },
 
   /**
@@ -217,6 +219,56 @@ var ControlBar = React.createClass({
    */
   handleControlBarBlur: function(evt) {
     this.props.controller.state.focusedControl = null;
+  },
+
+  /**
+   * Will handle the keydown event when the controlBar is active and it will restrict
+   * tab navigation to elements that are within it when the player is in fullscreen mode.
+   * @private
+   * @param {Object} evt Keydown event object.
+   */
+  handleControlBarKeyDown: function(evt) {
+    if (
+      evt.key !== CONSTANTS.KEY_VALUES.TAB
+      || !this.props.controller.state.fullscreen
+      || !this.domNode
+      || !evt.target
+    ) {
+      return;
+    }
+    // Focusable elements on the control bar (this.domNode) are expected to have the
+    // data-focus-id attribute
+    var focusableElements = this.domNode.querySelectorAll('[data-focus-id]');
+
+    if (focusableElements.length) {
+      var firstFocusableElement = focusableElements[0];
+      var lastFocusableElement = focusableElements[focusableElements.length - 1];
+      // This indicates we're tabbing over the focusable control bar elements
+      if (evt.target.hasAttribute('data-focus-id')) {
+        if (evt.shiftKey) {
+          // Shift + tabbing on first element, focus on last
+          if (evt.target === firstFocusableElement) {
+            evt.preventDefault();
+            lastFocusableElement.focus();
+          }
+        } else {
+          // Tabbing on last element, focus on first
+          if (evt.target === lastFocusableElement) {
+            evt.preventDefault();
+            firstFocusableElement.focus();
+          }
+        }
+      // Keydown happened on a non-controlbar element
+      } else {
+        evt.preventDefault();
+
+        if (evt.shiftKey) {
+          lastFocusableElement.focus();
+        } else {
+          firstFocusableElement.focus();
+        }
+      }
+    }
   },
 
   populateControlBar: function () {

--- a/tests/components/accessibilityControls-test.js
+++ b/tests/components/accessibilityControls-test.js
@@ -1,5 +1,6 @@
 jest.dontMock('../../js/components/accessibilityControls');
 jest.dontMock('../../js/constants/constants');
+jest.dontMock('../../js/components/utils');
 
 var CONSTANTS = require('../../js/constants/constants');
 var AccessibilityControls = require('../../js/components/accessibilityControls');
@@ -133,6 +134,147 @@ describe('AccessibilityControls', function () {
     accessibilityControls.handleKey(mockEvent)
   });
 
+  describe('API', function() {
+    var mockCtrl, a11yCtrls;
 
+    beforeEach(function() {
+      mockCtrl = {
+        state: {
+          accessibilityControlsEnabled: true,
+          screenToShow: CONSTANTS.SCREEN.PLAYING_SCREEN,
+          volumeState: {
+            volume: 0
+          }
+        },
+        skin: {
+          state: {
+            currentPlayhead: 0,
+            duration: 60
+          }
+        },
+        setVolume: function() {},
+        seek: function() {},
+        updateSeekingPlayhead: function() {}
+      };
+      a11yCtrls = new AccessibilityControls(mockCtrl);
+    });
+
+    describe('canSeek', function() {
+
+      it('should only allow seeking on playing, pause and end screens', function() {
+        for (var currentScreen in CONSTANTS.SCREEN) {
+          mockCtrl.state.screenToShow = currentScreen;
+          switch (currentScreen) {
+            case CONSTANTS.SCREEN.PLAYING_SCREEN:
+            case CONSTANTS.SCREEN.PAUSE_SCREEN:
+            case CONSTANTS.SCREEN.END_SCREEN:
+              expect(a11yCtrls.canSeek()).toBe(true);
+              break;
+            default:
+              expect(a11yCtrls.canSeek()).toBe(false);
+              break;
+          }
+        }
+      });
+
+      it ('should disable seeking when an ad is playing', function() {
+        mockCtrl.state.screenToShow = CONSTANTS.SCREEN.PLAYING_SCREEN;
+        mockCtrl.state.isPlayingAd = true;
+        expect(a11yCtrls.canSeek()).toBe(false);
+      });
+
+    });
+
+    describe('changeVolumeBy', function() {
+
+      it('should increase and decrease the volume', function() {
+        var volume = 0;
+        mockCtrl.setVolume = function(vol) {
+          volume = vol;
+        };
+        mockCtrl.state.volumeState.volume = 0;
+        a11yCtrls.changeVolumeBy(100, true);
+        expect(volume).toBe(1);
+        mockCtrl.state.volumeState.volume = 1;
+        a11yCtrls.changeVolumeBy(100, false);
+        expect(volume).toBe(0);
+        mockCtrl.state.volumeState.volume = 0.5;
+        a11yCtrls.changeVolumeBy(25, true);
+        expect(volume).toBe(0.75);
+      });
+
+      it('should not call controller.setVolume() when requested change results in current volume', function() {
+        var setVolumeCalled = false;
+        mockCtrl.setVolume = function() {
+          setVolumeCalled = true;
+        };
+        mockCtrl.state.volumeState.volume = 0;
+        a11yCtrls.changeVolumeBy(100, false);
+        expect(setVolumeCalled).toBe(false);
+      });
+
+      it('should constrain volume to supported values', function() {
+        var volume = 0;
+        mockCtrl.setVolume = function(vol) {
+          volume = vol;
+        };
+        mockCtrl.state.volumeState.volume = 0.5;
+        a11yCtrls.changeVolumeBy(500, true);
+        expect(volume).toBe(1);
+        a11yCtrls.changeVolumeBy(500, false);
+        expect(volume).toBe(0);
+      });
+
+    });
+
+    describe('seekBy', function() {
+      var newPlayhead;
+
+      beforeEach(function() {
+        newPlayhead = null;
+        mockCtrl.seek = function(seekTo) {
+          newPlayhead = seekTo;
+        };
+      });
+
+      it('should seek the specified amount of seconds forward', function() {
+        mockCtrl.skin.state.duration = 60;
+        mockCtrl.skin.state.currentPlayhead = 0;
+        a11yCtrls.seekBy(5, true);
+        expect(newPlayhead).toBe(5);
+      });
+
+      it('should seek back the specified amount of seconds', function() {
+        mockCtrl.skin.state.duration = 60;
+        mockCtrl.skin.state.currentPlayhead = 10;
+        a11yCtrls.seekBy(5, false);
+        expect(newPlayhead).toBe(5);
+      });
+
+      it('should not seek past the video\'s duration', function() {
+        mockCtrl.skin.state.duration = 60;
+        mockCtrl.skin.state.currentPlayhead = 10;
+        a11yCtrls.seekBy(120, true);
+        expect(newPlayhead).toBe(mockCtrl.skin.state.duration);
+      });
+
+      it('should not seek past the video\'s start time', function() {
+        mockCtrl.skin.state.duration = 60;
+        mockCtrl.skin.state.currentPlayhead = 30;
+        a11yCtrls.seekBy(120, false);
+        expect(newPlayhead).toBe(0);
+      });
+
+      it('should not seek when seeking is disabled', function() {
+        mockCtrl.state.screenToShow = CONSTANTS.SCREEN.AD_SCREEN;
+        mockCtrl.skin.state.duration = 60;
+        mockCtrl.skin.state.currentPlayhead = 0;
+        a11yCtrls.seekBy(5, true);
+        expect(newPlayhead).toBeNull();
+      });
+
+    });
+
+  });
 
 });

--- a/tests/components/accessibilityControls-test.js
+++ b/tests/components/accessibilityControls-test.js
@@ -223,6 +223,10 @@ describe('AccessibilityControls', function () {
         expect(volume).toBe(1);
         a11yCtrls.changeVolumeBy(500, false);
         expect(volume).toBe(0);
+        a11yCtrls.changeVolumeBy(-500, true);
+        expect(volume).toBe(0);
+        a11yCtrls.changeVolumeBy(-500, false);
+        expect(volume).toBe(0);
       });
 
     });
@@ -249,6 +253,13 @@ describe('AccessibilityControls', function () {
         mockCtrl.skin.state.currentPlayhead = 10;
         a11yCtrls.seekBy(5, false);
         expect(newPlayhead).toBe(5);
+      });
+
+      it('should handle negative values gracefully by inverting the direction of the seek', function() {
+        mockCtrl.skin.state.duration = 60;
+        mockCtrl.skin.state.currentPlayhead = 10;
+        a11yCtrls.seekBy(-5, false);
+        expect(newPlayhead).toBe(15);
       });
 
       it('should not seek past the video\'s duration', function() {

--- a/tests/components/controlBar-test.js
+++ b/tests/components/controlBar-test.js
@@ -1652,7 +1652,7 @@ describe('ControlBar', function () {
   });
 
   describe('Tab Navigation', function() {
-    var eventMap, ctrlBarElement, focusableElements, mockEvent;
+    var eventMap, ctrlBarElement, focusableElements, mockEvent, originalAddEventListener;
 
     beforeEach(function() {
       baseMockProps.skinConfig.buttons.desktopContent = [
@@ -1662,9 +1662,10 @@ describe('ControlBar', function () {
       ];
       // Mock addEventListener on document object since TestUtils.Simulate will not work in this case
       eventMap = {};
-      document.addEventListener = jest.genMockFn().mockImpl(function(event, cb) {
+      originalAddEventListener = document.addEventListener;
+      document.addEventListener = function(event, cb) {
         eventMap[event] = cb;
-      });
+      };
       ReactDOM.render(
         <ControlBar
           {...baseMockProps}
@@ -1680,6 +1681,8 @@ describe('ControlBar', function () {
 
     afterEach(function() {
       ReactDOM.unmountComponentAtNode(document.body);
+      // Our version of jest doesn't seem to support mockRestore()
+      document.addEventListener = originalAddEventListener;
       document.body.innerHTML = '';
     });
 

--- a/tests/components/controlBar-test.js
+++ b/tests/components/controlBar-test.js
@@ -347,6 +347,30 @@ describe('ControlBar', function () {
     expect(baseMockController.state.focusedControl).toBe(null);
   });
 
+  it('should start auto hide timer after restoring focused control', function() {
+    var startHideControlBarTimerCalled = false;
+    baseMockProps.skinConfig.buttons.desktopContent = [
+      { "name": "playPause", "location": "controlBar", "whenDoesNotFit": "keep", "minWidth": 45 }
+    ];
+    baseMockController.startHideControlBarTimer = function() {
+      startHideControlBarTimerCalled = true;
+    };
+    var controlBar = (
+      <ControlBar
+        {...baseMockProps}
+        controlBarVisible={true}
+        componentWidth={500}
+        playerState={CONSTANTS.STATE.PLAYING}
+        isLiveStream={baseMockProps.isLiveStream} />
+    );
+    baseMockController.state.focusedControl = null;
+    var DOM = TestUtils.renderIntoDocument(controlBar);
+    expect(startHideControlBarTimerCalled).toBe(false);
+    baseMockController.state.focusedControl = 'playPause';
+    var DOM = TestUtils.renderIntoDocument(controlBar);
+    expect(startHideControlBarTimerCalled).toBe(true);
+  });
+
   it('to toggle share screen', function() {
     var shareClicked = false;
     var mockController = {

--- a/tests/components/scrubberBar-test.js
+++ b/tests/components/scrubberBar-test.js
@@ -130,6 +130,49 @@ describe('ScrubberBar', function () {
     expect(scrubberBar.getAttribute('aria-valuetext')).toBe('01:00 of 01:00');
   });
 
+  it('should use different ARIA value text for live videos', function() {
+    baseMockController.state.isLiveStream = true;
+    baseMockController.state.currentPlayhead = 2;
+    baseMockController.state.duration = 0;
+    updateBaseMockProps();
+    var DOM = TestUtils.renderIntoDocument(<ScrubberBar {...baseMockProps}/>);
+    var scrubberBar = TestUtils.findRenderedDOMComponentWithClass(DOM, "oo-scrubber-bar");
+    expect(scrubberBar.getAttribute('aria-valuetext')).toBe('Live video');
+
+    baseMockController.state.currentPlayhead = 60;
+    baseMockController.state.duration = 120;
+    updateBaseMockProps();
+    DOM = TestUtils.renderIntoDocument(<ScrubberBar {...baseMockProps}/>);
+    scrubberBar = TestUtils.findRenderedDOMComponentWithClass(DOM, "oo-scrubber-bar");
+    expect(scrubberBar.getAttribute('aria-valuetext')).toBe('01:00 of 02:00 live video');
+  });
+
+  it('should call a11y ctrls seek method when arrow keys are pressed', function() {
+    var seekForwardCalled = 0;
+    var seekBackCalled = 0;
+    baseMockController.state.duration = 60;
+    baseMockController.accessibilityControls = {
+      seekBy: function(seconds, forward) {
+        if (forward) {
+          seekForwardCalled++;
+        } else {
+          seekBackCalled++;
+        }
+      }
+    };
+    updateBaseMockProps();
+    var DOM = TestUtils.renderIntoDocument(<ScrubberBar {...baseMockProps}/>);
+    var scrubberBar = TestUtils.findRenderedDOMComponentWithClass(DOM, "oo-scrubber-bar");
+    TestUtils.Simulate.keyDown(scrubberBar, { key: CONSTANTS.KEY_VALUES.ARROW_UP });
+    TestUtils.Simulate.keyDown(scrubberBar, { key: CONSTANTS.KEY_VALUES.ARROW_RIGHT });
+    expect(seekForwardCalled).toBe(2);
+    expect(seekBackCalled).toBe(0);
+    TestUtils.Simulate.keyDown(scrubberBar, { key: CONSTANTS.KEY_VALUES.ARROW_DOWN });
+    TestUtils.Simulate.keyDown(scrubberBar, { key: CONSTANTS.KEY_VALUES.ARROW_LEFT });
+    expect(seekForwardCalled).toBe(2);
+    expect(seekBackCalled).toBe(2);
+  });
+
   it('creates a scrubber bar played bar and play head with scrubberbar played color setting', function () {
     var mockController = {
       state: {

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -32,6 +32,69 @@ describe('Utils', function () {
     expect(browserSupportsTouch).toBeFalsy();
   });
 
+  describe('blurOnMouseUp', function() {
+
+    it('should call blur() on currentTarget', function() {
+      var blurCalled = false;
+      var event = {
+        currentTarget: {
+          blur: function() {
+            blurCalled = true;
+          }
+        }
+      };
+      Utils.blurOnMouseUp(event);
+      expect(blurCalled).toBe(true);
+    });
+
+  });
+
+  describe('ensureNumber', function() {
+
+    it('should return the Number equivalent of a string', function() {
+      expect(Utils.ensureNumber('233')).toBe(233);
+      expect(Utils.ensureNumber('10.233')).toBe(10.233);
+    });
+
+    it('should return null when the input value is not finite or a parsable Number', function() {
+      expect(Utils.ensureNumber('w00t233')).toBeNull();
+      expect(Utils.ensureNumber(Infinity)).toBeNull();
+      expect(Utils.ensureNumber({})).toBeNull();
+      expect(Utils.ensureNumber(NaN)).toBeNull();
+    });
+
+    it('should return defaultValue when provided if input value is not finite or a parsable Number', function() {
+      expect(Utils.ensureNumber('w00t233', 1)).toBe(1);
+      expect(Utils.ensureNumber(Infinity, 2)).toBe(2);
+      expect(Utils.ensureNumber({}, 'error')).toBe('error');
+      expect(Utils.ensureNumber(NaN, 3)).toBe(3);
+    });
+
+  });
+
+  describe('constrainToRange', function() {
+
+    it('should return the Number equivalent of value if it falls within range', function() {
+      expect(Utils.constrainToRange(5, 1, 10)).toBe(5);
+      expect(Utils.constrainToRange(0, -5, 5)).toBe(0);
+      expect(Utils.constrainToRange('50', '1', '100')).toBe(50);
+    });
+
+    it('should return min or max when value is outside of range', function() {
+      expect(Utils.constrainToRange(1, 5, 10)).toBe(5);
+      expect(Utils.constrainToRange(15, 5, 10)).toBe(10);
+      expect(Utils.constrainToRange(-10, 0, 100)).toBe(0);
+    });
+
+    it('should return the Number equivalent of input values', function() {
+      expect(Utils.constrainToRange(1, '5', 10)).toBe(5);
+      expect(Utils.constrainToRange(15, 5, '10')).toBe(10);
+      expect(Utils.constrainToRange(-10, '0', 100)).toBe(0);
+      expect(Utils.constrainToRange('50', '1', '100')).toBe(50);
+    });
+
+  });
+
   describe('getTimeDisplayValues', function() {
 
     it('should return formatted currentTime and totalTime for VOD', function() {

--- a/tests/components/volumeControls-test.js
+++ b/tests/components/volumeControls-test.js
@@ -1,0 +1,123 @@
+jest
+.dontMock('../../js/components/volumeControls')
+.dontMock('../../js/components/utils')
+.dontMock('../../js/constants/constants')
+.dontMock('../../config/skin.json')
+.dontMock('classnames');
+
+var React = require('react');
+var ReactDOM = require('react-dom');
+var TestUtils = require('react-addons-test-utils');
+var VolumeControls = require('../../js/components/volumeControls');
+var defaultSkinConfig = require('../../config/skin.json');
+var CONSTANTS = require('../../js/constants/constants');
+
+describe('VolumeControls', function() {
+  var mockCtrl, skinConfig;
+
+  beforeEach(function() {
+    mockCtrl = {
+      state: {
+        isMobile: false,
+        volumeState: {
+          volumeSliderVisible: false,
+          volume: 1.0
+        }
+      },
+      setVolume: function(volume) {
+        mockCtrl.state.volumeState.volume = volume;
+      },
+      accessibilityControls: {
+        changeVolumeBy: function() {}
+      }
+    };
+    skinConfig = JSON.parse(JSON.stringify(defaultSkinConfig));
+  });
+
+  it('should change volume according to value of clicked volume bar', function() {
+    var DOM = TestUtils.renderIntoDocument(
+      <VolumeControls controller={mockCtrl} skinConfig={skinConfig} />
+    );
+    var volumeBars = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-volume-bar');
+    TestUtils.Simulate.click(volumeBars[4], { target: { dataset: { volume: 0.5 } } });
+    expect(mockCtrl.state.volumeState.volume).toBe(0.5);
+    TestUtils.Simulate.click(volumeBars[0], { target: { dataset: { volume: 0.1 } } });
+    expect(mockCtrl.state.volumeState.volume).toBe(0.1);
+  });
+
+  it('should set active css class on bars that match the current volume level', function() {
+    mockCtrl.state.volumeState.volume = 0.5;
+    var DOM = TestUtils.renderIntoDocument(
+      <VolumeControls controller={mockCtrl} skinConfig={skinConfig} />
+    );
+    var volumeBars = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-volume-bar');
+    for (var i = 0; i < volumeBars.length; i++) {
+      var volumeBar = volumeBars[i];
+      if (i < 5) {
+        expect(volumeBar.className).toEqual('oo-volume-bar oo-on');
+      } else {
+        expect(volumeBar.className).toEqual('oo-volume-bar');
+      }
+    }
+  });
+
+  it('should set the right ARIA attributes on volume controls', function() {
+    mockCtrl.state.volumeState.volume = 0.5;
+    var DOM = TestUtils.renderIntoDocument(
+      <VolumeControls controller={mockCtrl} skinConfig={skinConfig} />
+    );
+    var volumeControls = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-volume-controls');
+    expect(volumeControls.getAttribute('aria-label')).toBe(CONSTANTS.ARIA_LABELS.VOLUME_SLIDER);
+    expect(volumeControls.getAttribute('aria-valuemin')).toBe('0');
+    expect(volumeControls.getAttribute('aria-valuemax')).toBe('100');
+    expect(volumeControls.getAttribute('aria-valuenow')).toBe('50');
+    expect(volumeControls.getAttribute('aria-valuetext')).toBe('50% volume');
+  });
+
+  it('should allow changing the volume with the keyboard', function() {
+    var increaseVolumeCalled = 0;
+    var decreaseVolumeCalled = 0;
+    mockCtrl.accessibilityControls = {
+      changeVolumeBy: function(percent, increase) {
+        if (increase) {
+          increaseVolumeCalled++;
+        } else {
+          decreaseVolumeCalled++;
+        }
+      }
+    };
+    var DOM = TestUtils.renderIntoDocument(
+      <VolumeControls controller={mockCtrl} skinConfig={skinConfig} />
+    );
+    var volumeControls = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-volume-controls');
+    TestUtils.Simulate.keyDown(volumeControls, { key: CONSTANTS.KEY_VALUES.ARROW_UP });
+    TestUtils.Simulate.keyDown(volumeControls, { key: CONSTANTS.KEY_VALUES.ARROW_RIGHT });
+    expect(increaseVolumeCalled).toBe(2);
+    expect(decreaseVolumeCalled).toBe(0);
+    TestUtils.Simulate.keyDown(volumeControls, { key: CONSTANTS.KEY_VALUES.ARROW_DOWN });
+    TestUtils.Simulate.keyDown(volumeControls, { key: CONSTANTS.KEY_VALUES.ARROW_LEFT });
+    expect(increaseVolumeCalled).toBe(2);
+    expect(decreaseVolumeCalled).toBe(2);
+  });
+
+  it('should change volume by 100% when using the HOME or END keys', function() {
+    var volumePercent, volumeIncrease;
+    mockCtrl.accessibilityControls = {
+      changeVolumeBy: function(percent, increase) {
+        volumePercent = percent;
+        volumeIncrease = increase;
+      }
+    };
+    var DOM = TestUtils.renderIntoDocument(
+      <VolumeControls controller={mockCtrl} skinConfig={skinConfig} />
+    );
+    var volumeControls = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-volume-controls');
+    TestUtils.Simulate.keyDown(volumeControls, { key: CONSTANTS.KEY_VALUES.HOME });
+    expect(volumePercent).toBe(100);
+    expect(volumeIncrease).toBe(false);
+    TestUtils.Simulate.keyDown(volumeControls, { key: CONSTANTS.KEY_VALUES.END });
+    expect(volumePercent).toBe(100);
+    expect(volumeIncrease).toBe(true);
+  });
+
+});


### PR DESCRIPTION
[PLAYER-1598]

- Added all the pending unit tests for scrubber and volume bar accessibility updates.

 [PLAYER-1698]

- Restricting tab navigation to control bar elements when player is in fullscreen mode. Tab focus will loop around on player elements only.