### PR TITLE
[PLAYER-1761] Delaying rendering of loading spinner

### DIFF
--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -148,7 +148,8 @@ module.exports = {
 
   UI: {
     defaultScrubberBarHeight: 4,
-    DEFAULT_SCRUBBERBAR_LEFT_RIGHT_PADDING: 15
+    DEFAULT_SCRUBBERBAR_LEFT_RIGHT_PADDING: 15,
+    BUFFERING_SPINNER_DELAY: 1000
   },
 
   WATERMARK: {

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -149,7 +149,7 @@ module.exports = {
   UI: {
     defaultScrubberBarHeight: 4,
     DEFAULT_SCRUBBERBAR_LEFT_RIGHT_PADDING: 15,
-    BUFFERING_SPINNER_DELAY: 1000
+    BUFFERING_SPINNER_DELAY: 1250
   },
 
   WATERMARK: {

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -149,7 +149,7 @@ module.exports = {
   UI: {
     defaultScrubberBarHeight: 4,
     DEFAULT_SCRUBBERBAR_LEFT_RIGHT_PADDING: 15,
-    BUFFERING_SPINNER_DELAY: 1250
+    MAX_BUFFERING_SPINNER_DELAY: 60000 // Max allowed value of bufferingSpinnerDelay in milliseconds
   },
 
   WATERMARK: {

--- a/js/controller.js
+++ b/js/controller.js
@@ -608,6 +608,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       }
       this.skin.updatePlayhead(this.state.duration, this.state.duration, this.state.duration);
       this.state.playerState = CONSTANTS.STATE.END;
+      // In case a video plugin fires PLAYED event after stalling without firing BUFFERED or PLAYING first
+      this.setBufferingState(false);
       this.renderSkin();
     },
 
@@ -673,10 +675,12 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
      */
     startBufferingTimer: function() {
       this.stopBufferingTimer();
+      var bufferingSpinnerDelay = Utils.getPropertyValue(this.skin.props.skinConfig, 'general.bufferingSpinnerDelay');
+      bufferingSpinnerDelay = Utils.constrainToRange(bufferingSpinnerDelay, 0, CONSTANTS.UI.MAX_BUFFERING_SPINNER_DELAY);
 
       this.state.bufferingTimer = setTimeout(function() {
         this.setBufferingState(true);
-      }.bind(this), CONSTANTS.UI.BUFFERING_SPINNER_DELAY);
+      }.bind(this), bufferingSpinnerDelay);
     },
 
     /**

--- a/js/controller.js
+++ b/js/controller.js
@@ -73,7 +73,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       "mainVideoAspectRatio": 0,
       "pluginsElement": null,
       "pluginsClickElement": null,
-      "buffering": false,
+      "buffering": false, // Do NOT set manually, call setBufferingState
       "mainVideoBuffered": null,
       "mainVideoPlayhead": 0,
       "adVideoPlayhead": 0,
@@ -294,7 +294,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       if (mountNode) {
         ReactDOM.unmountComponentAtNode(mountNode);
       }
-      this.cleanUpEventListeners()
+      this.stopBufferingTimer();
+      this.cleanUpEventListeners();
       this.mb = null;
     },
 
@@ -507,7 +508,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.renderSkin();
       }
       if (source == OO.VIDEO.ADS) {
-        this.setBufferingState(false);
         this.state.adPauseAnimationDisabled = true;
         this.state.pluginsElement.addClass("oo-showing");
         this.state.pluginsClickElement.removeClass("oo-showing");
@@ -518,6 +518,9 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
           this.renderSkin();
         }
       }
+      // For the off chance that a video plugin resumes playback without firing
+      // the ON_BUFFERED event. This will have no effect if it was set previously
+      this.setBufferingState(false);
     },
 
     onPause: function(event, source, pauseReason) {
@@ -669,6 +672,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
      * @private
      */
     startBufferingTimer: function() {
+      this.stopBufferingTimer();
+
       this.state.bufferingTimer = setTimeout(function() {
         this.setBufferingState(true);
       }.bind(this), CONSTANTS.UI.BUFFERING_SPINNER_DELAY);

--- a/js/controller.js
+++ b/js/controller.js
@@ -737,6 +737,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.state.pluginsClickElement.removeClass("oo-showing");
       // Restore anamorphic videos fix after ad playback if necessary
       this.trySetAnamorphicFixState(true);
+      // In case ad was skipped or errored while stalled
+      this.setBufferingState(false);
       this.renderSkin();
     },
 
@@ -858,6 +860,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     onVideoElementFocus: function(event, source) {
+      // Switching to another element, clear buffering state which applies to current element
+      if (this.focusedElement !== source) {
+        this.setBufferingState(false);
+      }
       this.focusedElement = source;
       // Make sure that the skin uses the captions that correspond
       // to the newly focused video element
@@ -1151,6 +1157,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
 
     onErrorEvent: function(event, errorCode){
       this.unsubscribeBasicPlaybackEvents();
+      this.setBufferingState(false);
 
       this.state.screenToShow = CONSTANTS.SCREEN.ERROR_SCREEN;
       this.state.playerState = CONSTANTS.STATE.ERROR;

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -180,6 +180,9 @@ OO = {
       exitFullWindow: function() {},
       exitFullWindowOnEscKey: function() {},
       onBuffered: function() {},
+      setBufferingState: function() {},
+      startBufferingTimer: function() {},
+      stopBufferingTimer: function() {},
       onInitialPlayRequested: function() {},
       unsubscribeBasicPlaybackEvents: function() {},
       resetUpNextInfo: function(a) {},
@@ -561,7 +564,7 @@ OO = {
         Html5Skin.onPlayerCreated.call(controllerMock, 'customerUi', 'elementId', {});
         expect(controllerMock.state.screenToShow).toBe(CONSTANTS.SCREEN.INITIAL_SCREEN);
       });
-      
+
     });
 
     describe('Controller testing Ooyala Ads', function () {

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -1,3 +1,38 @@
+/*
+ *
+ *  !!!IMPORTANT!!!
+ *
+ *  This file is deprecated. Please use html5skin-test.js for all new controller unit tests.
+ *
+ *  !!!IMPORTANT!!!
+ *
+ */
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 jest.dontMock('../js/controller');
 jest.dontMock('screenfull');
 jest.dontMock('../js/constants/constants');

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -1,0 +1,155 @@
+jest
+.dontMock('../js/components/utils')
+.dontMock('../js/components/accessibilityControls')
+.dontMock('../js/constants/constants')
+.dontMock('../config/skin.json')
+.dontMock('classnames');
+
+var CONSTANTS = require('../js/constants/constants');
+var sinon = require('sinon');
+
+var Html5Skin, defaultSkinState;
+
+// Mock OO environment needed for skin plugin initialization
+OO = {
+  playerParams: {
+    "core_version" : 4
+  },
+  publicApi: {},
+  EVENTS: {},
+  CONSTANTS: {
+    CLOSED_CAPTIONS: {}
+  },
+  VIDEO: {
+    ADS: 'ads',
+    MAIN: 'main'
+  },
+  init: function() {},
+  plugin: function(module, callback) {
+    var _ = require('underscore');
+    var $ = require('jquery');
+    var plugin = callback(OO, _, $);
+    plugin.call(OO, OO.mb, 0);
+    // Save Html5Skin class in local var
+    Html5Skin = exposeStaticApi;
+  },
+  mb: {
+    subscribe: function() {},
+    unsubscribe: function() {},
+    publish: function() {},
+    addDependent: function() {}
+  }
+};
+// Requiring this will automatically initialize the plugin and set the Html5Skin var
+require('../js/controller');
+
+describe('Controller', function() {
+  var controller;
+
+  beforeEach(function() {
+    controller = new Html5Skin(OO.mb, 'id');
+    controller.state.mainVideoElement = {
+      classList: {
+        add: function() {},
+        remove: function() {}
+      },
+      getElementsByTagName: function() { return [controller.state.mainVideoElement] },
+      webkitSupportsFullscreen: true,
+      webkitEnterFullscreen: function() {},
+      webkitExitFullscreen: function() {},
+      addEventListener: function() {}
+    };
+  });
+
+  describe('Buffering state', function() {
+
+    it('should update buffering state', function() {
+      controller.setBufferingState(false);
+      expect(controller.state.buffering).toBe(false);
+      controller.setBufferingState(true);
+      expect(controller.state.buffering).toBe(true);
+    });
+
+    it('should not render skin if new buffering state is the same as the current one', function() {
+      var spy = sinon.spy(controller, 'renderSkin');
+      controller.state.buffering = false;
+      controller.setBufferingState(false);
+      controller.state.buffering = true;
+      controller.setBufferingState(true);
+      expect(spy.callCount).toBe(0);
+      spy.restore();
+    });
+
+    it('should stop buffering timer before starting a new one', function() {
+      var spy = sinon.spy(controller, 'stopBufferingTimer');
+      controller.startBufferingTimer();
+      expect(spy.callCount).toBe(1);
+      expect(controller.state.bufferingTimer).toBeTruthy();
+      controller.stopBufferingTimer();
+      spy.restore();
+    });
+
+    it('should stop buffering timer when setting buffering state to false', function() {
+      var spy = sinon.spy(controller, 'stopBufferingTimer');
+      controller.startBufferingTimer();
+      expect(spy.callCount).toBe(1);
+      expect(controller.state.bufferingTimer).toBeTruthy();
+      controller.setBufferingState(false);
+      expect(spy.callCount).toBe(2);
+      expect(controller.state.bufferingTimer).toBeFalsy();
+      spy.restore();
+    });
+
+    it('should cancel buffering timer when ON_BUFFERED event is fired', function() {
+      var spy = sinon.spy(controller, 'stopBufferingTimer');
+      controller.startBufferingTimer();
+      expect(spy.callCount).toBe(1);
+      expect(controller.state.bufferingTimer).toBeTruthy();
+      controller.onBuffered();
+      expect(spy.callCount).toBe(2);
+      expect(controller.state.bufferingTimer).toBeFalsy();
+      expect(controller.state.buffering).toBe(false);
+      spy.restore();
+    });
+
+    it('should delay buffering state and start buffering timer when ON_BUFFERING event is fired', function() {
+      var spy = sinon.spy(controller, 'startBufferingTimer');
+      controller.state.isInitialPlay = false;
+      controller.state.screenToShow = CONSTANTS.PLAYING_SCREEN;
+      controller.onBuffering();
+      expect(controller.state.buffering).toBe(false);
+      expect(spy.callCount).toBe(1);
+      expect(controller.state.bufferingTimer).toBeTruthy();
+      controller.stopBufferingTimer();
+      spy.restore();
+    });
+
+    it('should set buffering state to true after buffering timer time has elapsed', function() {
+      controller.startBufferingTimer();
+      expect(controller.state.buffering).toBe(false);
+      jest.runAllTimers();
+      expect(controller.state.buffering).toBe(true);
+    });
+
+    it('should reset buffering state if it hasn\'t been cleared by the time PLAYING is fired', function() {
+      controller.setBufferingState(true);
+      expect(controller.state.buffering).toBe(true);
+      controller.onPlaying('', OO.VIDEO.MAIN);
+      expect(controller.state.buffering).toBe(false);
+    });
+
+    it('should stop buffering timer when plugin is destroyed', function() {
+      var spy = sinon.spy(controller, 'stopBufferingTimer');
+      controller.accessibilityControls = { cleanUp: function() {} };
+      controller.startBufferingTimer();
+      expect(spy.callCount).toBe(1);
+      expect(controller.state.bufferingTimer).toBeTruthy();
+      controller.onPlayerDestroy({});
+      expect(spy.callCount).toBe(2);
+      expect(controller.state.bufferingTimer).toBeFalsy();
+      spy.restore();
+    });
+
+  });
+
+});


### PR DESCRIPTION
The skin will no longer render the loading spinner immediately after the video stalls. When a stalling event occurs the skin will wait for a specified amount of time and then it will render the spinner. If playback resumes before the time elapses the spinner will simply be cancelled.