### PR TITLE
[PLAYER-1270] Perceived performance enhancements (part two)

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -682,9 +682,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       if (this.state.afterOoyalaAd) {
         this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
       } else {
-        // If we have played a video before and PLAYBACK_READY fires it means
-        // we're transitioning to a new video. For the time being this will autoplay
-        // the next video, so we only show the loading spinner in these cases.
+        // If the core tells us that it will autoplay then we just display the loading
+        // spinner, otherwise we need to render the big play button.
         if (params.willAutoplay) {
           this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
         } else {

--- a/js/controller.js
+++ b/js/controller.js
@@ -43,7 +43,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       "isLiveStream": false,
       "screenToShow": null,
       "playerState": null,
-      "hasPlayed": false, // Determines whether playback has started for any video on this player
       "discoveryData": null,
       "forceCountDownTimerOnEndScreen": false,
       "isPlayingAd": false,
@@ -52,7 +51,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       "showAdOverlayCloseButton": false,
       "showAdControls": true,
       "showAdMarquee": true,
-      "isAsset": false,
       "isOoyalaAds": false,
       "afterOoyalaAd": false,
       "configLoaded": false,
@@ -143,6 +141,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       "isPlaybackReadySubscribed": false,
       "isSkipAdClicked": false,
       "isInitialPlay": false,
+      "initialPlayHasOccurred": false,
       "isFullScreenSupported": false,
       "isVideoFullScreenSupported": false,
       "isFullWindow": false,
@@ -329,7 +328,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     onSetEmbedCode: function(event, embedCode) {
       // If a video has played and we're setting a new embed code it means that we
       // will be transitioning to a new video. We make sure to display the loading screen.
-      if (this.state.hasPlayed && this.state.assetId !== embedCode) {
+      if (this.state.initialPlayHasOccurred && this.state.assetId !== embedCode) {
         this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
         this.renderSkin();
       }
@@ -344,7 +343,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     onEmbedCodeChanged: function(event, embedCode, options) {
-      this.state.isAsset = false;
       this.state.videoQualityOptions.availableBitrates = null;
       this.state.videoQualityOptions.selectedBitrate = null;
       this.state.closedCaptionOptions.availableLanguages = null;
@@ -400,7 +398,6 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     onAssetChanged: function (event, asset) {
-      this.state.isAsset = true;
       this.state.videoQualityOptions.availableBitrates = null;
       this.state.closedCaptionOptions.availableLanguages = null;
       this.state.closedCaptionsInfoCache = {};
@@ -531,12 +528,11 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
 
     onInitialPlay: function() {
       this.state.isInitialPlay = true;
+      this.state.initialPlayHasOccurred = true;
       this.startHideControlBarTimer();
     },
 
     onPlaying: function(event, source) {
-      this.state.hasPlayed = true;
-
       if (source == OO.VIDEO.MAIN) {
         //set mainVideoElement if not set during video plugin initialization
         if (!this.state.mainVideoMediaType) {
@@ -687,9 +683,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         // If we have played a video before and PLAYBACK_READY fires it means
         // we're transitioning to a new video. For the time being this will autoplay
         // the next video, so we only show the loading spinner in these cases.
-        // Note that the standalone player (this.state.isAsset === true) doesn't currently
-        // autoplay, so we need to use the start screen when using it.
-        if (this.state.hasPlayed && !this.state.isAsset) {
+        if (this.state.initialPlayHasOccurred) {
           this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
         } else {
           this.state.screenToShow = CONSTANTS.SCREEN.START_SCREEN;

--- a/js/controller.js
+++ b/js/controller.js
@@ -52,6 +52,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       "showAdOverlayCloseButton": false,
       "showAdControls": true,
       "showAdMarquee": true,
+      "isAsset": false,
       "isOoyalaAds": false,
       "afterOoyalaAd": false,
       "configLoaded": false,
@@ -343,6 +344,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     onEmbedCodeChanged: function(event, embedCode, options) {
+      this.state.isAsset = false;
       this.state.videoQualityOptions.availableBitrates = null;
       this.state.videoQualityOptions.selectedBitrate = null;
       this.state.closedCaptionOptions.availableLanguages = null;
@@ -398,6 +400,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
     },
 
     onAssetChanged: function (event, asset) {
+      this.state.isAsset = true;
       this.state.videoQualityOptions.availableBitrates = null;
       this.state.closedCaptionOptions.availableLanguages = null;
       this.state.closedCaptionsInfoCache = {};
@@ -417,6 +420,8 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
 
       this.state.contentTree = contentTree;
       this.state.playerState = CONSTANTS.STATE.START;
+      // Make sure playhead is reset when we switch to a new video
+      this.skin.updatePlayhead(0, contentTree.duration, 0, 0);
       this.renderSkin({"contentTree": contentTree});
     },
 
@@ -680,9 +685,11 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
       } else {
         // If we have played a video before and PLAYBACK_READY fires it means
-        // we're transitioning to a new video.
-        // We only show the loading spinner in these cases.
-        if (this.state.hasPlayed) {
+        // we're transitioning to a new video. For the time being this will autoplay
+        // the next video, so we only show the loading spinner in these cases.
+        // Note that the standalone player (this.state.isAsset === true) doesn't currently
+        // autoplay, so we need to use the start screen when using it.
+        if (this.state.hasPlayed && !this.state.isAsset) {
           this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
         } else {
           this.state.screenToShow = CONSTANTS.SCREEN.START_SCREEN;
@@ -1228,6 +1235,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       this.mb.unsubscribe(OO.EVENTS.PLAYBACK_READY, 'customerUi');
       this.mb.unsubscribe(OO.EVENTS.ERROR, "customerUi");
       this.mb.unsubscribe(OO.EVENTS.SET_EMBED_CODE_AFTER_OOYALA_AD, 'customerUi');
+      this.mb.unsubscribe(OO.EVENTS.SET_EMBED_CODE, 'customerUi');
     },
 
     unsubscribeBasicPlaybackEvents: function() {

--- a/js/controller.js
+++ b/js/controller.js
@@ -676,14 +676,16 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       }
     },
 
-    onPlaybackReady: function(event) {
+    onPlaybackReady: function(event, params) {
+      params = params || {};
+
       if (this.state.afterOoyalaAd) {
         this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
       } else {
         // If we have played a video before and PLAYBACK_READY fires it means
         // we're transitioning to a new video. For the time being this will autoplay
         // the next video, so we only show the loading spinner in these cases.
-        if (this.state.initialPlayHasOccurred) {
+        if (params.willAutoplay) {
           this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
         } else {
           this.state.screenToShow = CONSTANTS.SCREEN.START_SCREEN;

--- a/js/skin.js
+++ b/js/skin.js
@@ -61,10 +61,10 @@ var Skin = React.createClass({
 
   updatePlayhead: function(newPlayhead, newDuration, newBuffered, adPlayhead) {
     this.setState({
-      currentPlayhead: newPlayhead,
-      duration: newDuration,
-      buffered: newBuffered,
-      currentAdPlayhead: adPlayhead
+      currentPlayhead: Utils.ensureNumber(newPlayhead, this.state.currentPlayhead),
+      duration: Utils.ensureNumber(newDuration, this.state.duration),
+      buffered: Utils.ensureNumber(newBuffered, this.state.buffered),
+      currentAdPlayhead: Utils.ensureNumber(adPlayhead, this.state.currentAdPlayhead)
     });
   },
 

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -615,6 +615,7 @@ OO = {
 
       it('test start screen is shown on playback ready', function() {
         controllerMock.state.afterOoyalaAd = false;
+        controllerMock.state.hasPlayed = false;
         Html5Skin.onPlaybackReady.call(controllerMock, 'customerUi');
         expect(controllerMock.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
       });

--- a/tests/controller-test.js
+++ b/tests/controller-test.js
@@ -615,7 +615,7 @@ OO = {
 
       it('test start screen is shown on playback ready', function() {
         controllerMock.state.afterOoyalaAd = false;
-        controllerMock.state.hasPlayed = false;
+        controllerMock.state.initialPlayHasOccurred = false;
         Html5Skin.onPlaybackReady.call(controllerMock, 'customerUi');
         expect(controllerMock.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
       });

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -65,6 +65,18 @@ describe('Controller', function() {
     controller.state.pluginsElement = $('<div/>');
     controller.state.pluginsClickElement = $('<div/>');
     controller.state.mainVideoElement = mockDomElement;
+    controller.skin = {
+      state: {},
+      updatePlayhead: function(currentPlayhead, duration, buffered, currentAdPlayhead) {
+        this.state.currentPlayhead = currentPlayhead;
+        this.state.duration = duration;
+        this.state.buffered = buffered;
+        this.state.currentAdPlayhead = currentAdPlayhead;
+      },
+      props: {
+        skinConfig: JSON.parse(JSON.stringify(skinJson))
+      }
+    };
   });
 
   describe('Buffering state', function() {
@@ -73,12 +85,6 @@ describe('Controller', function() {
     beforeEach(function() {
       startBufferingTimerSpy = sinon.spy(controller, 'startBufferingTimer');
       stopBufferingTimerSpy = sinon.spy(controller, 'stopBufferingTimer');
-      controller.skin = {
-        updatePlayhead: function() {},
-        props: {
-          skinConfig: JSON.parse(JSON.stringify(skinJson))
-        }
-      };
     });
 
     afterEach(function() {
@@ -203,6 +209,77 @@ describe('Controller', function() {
       controller.onErrorEvent();
       expect(stopBufferingTimerSpy.callCount).toBe(8);
       expect(controller.state.bufferingTimer).toBeFalsy();
+    });
+
+  });
+
+  describe('New video transitions', function() {
+
+    it('should set hasPlayed to true if a video has started playback at least once', function() {
+      expect(controller.state.hasPlayed).toBe(false);
+      controller.onPlaying();
+      expect(controller.state.hasPlayed).toBe(true);
+    });
+
+    it('should trigger loading screen when embed code is set after video has started', function() {
+      controller.state.screenToShow = CONSTANTS.SCREEN.INITIAL_SCREEN;
+      controller.state.hasPlayed = true;
+      controller.onSetEmbedCode('newEmbedCode');
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
+    });
+
+    it('should show start screen on playback ready for first video', function() {
+      controller.onPlaybackReady();
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
+    });
+
+    it('should show loading screen on playback ready when switching videos', function() {
+      controller.onSetEmbedCode('oldEmbedCode');
+      controller.onPlaybackReady();
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
+      controller.onPlaying();
+      controller.onSetEmbedCode('newEmbedCode');
+      controller.onPlaybackReady();
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
+    });
+
+    it('should reset playhead on embed code changed', function() {
+      controller.onSetEmbedCode('oldEmbedCode');
+      controller.onPlaybackReady();
+      controller.onPlaying();
+      controller.onPlayheadTimeChanged('event', 5, 60, 30, null, OO.VIDEO.MAIN);
+      expect(controller.skin.state.currentPlayhead).toBe(5);
+      controller.onSetEmbedCode('newEmbedCode');
+      controller.onEmbedCodeChanged('newEmbedCode');
+      expect(controller.skin.state.currentPlayhead).toBe(0);
+    });
+
+    it('should reset playhead on asset changed', function() {
+      var asset = {
+        content: {
+          title: 'Title',
+          duration: 120,
+          description: 'Description',
+          captions: {},
+          posterImages: [{ url: 'url' }],
+          streams: [{ delivery_type: 'hls', url: 'url' }]
+        }
+      };
+      controller.onAssetChanged('event', asset);
+      controller.onPlaybackReady();
+      controller.onPlaying();
+      controller.onPlayheadTimeChanged('event', 5, 60, 30, null, OO.VIDEO.MAIN);
+      expect(controller.skin.state.currentPlayhead).toBe(5);
+      expect(controller.skin.state.duration).toBe(60);
+      controller.onAssetChanged('event', asset);
+      expect(controller.skin.state.currentPlayhead).toBe(0);
+      expect(controller.skin.state.duration).toBe(asset.content.duration);
+    });
+
+    it('should update skin duration on content tree fetched', function() {
+      expect(controller.skin.state.duration).not.toBe(120);
+      controller.onContentTreeFetched('event', { duration: 120000 });
+      expect(controller.skin.state.duration).toBe(120);
     });
 
   });

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -215,15 +215,15 @@ describe('Controller', function() {
 
   describe('New video transitions', function() {
 
-    it('should set hasPlayed to true if a video has started playback at least once', function() {
-      expect(controller.state.hasPlayed).toBe(false);
-      controller.onPlaying();
-      expect(controller.state.hasPlayed).toBe(true);
+    it('should set initialPlayHasOccurred to true if initial play has been requested', function() {
+      expect(controller.state.initialPlayHasOccurred).toBe(false);
+      controller.onInitialPlay();
+      expect(controller.state.initialPlayHasOccurred).toBe(true);
     });
 
     it('should trigger loading screen when embed code is set after video has started', function() {
       controller.state.screenToShow = CONSTANTS.SCREEN.INITIAL_SCREEN;
-      controller.state.hasPlayed = true;
+      controller.state.initialPlayHasOccurred = true;
       controller.onSetEmbedCode('newEmbedCode');
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
     });
@@ -237,7 +237,7 @@ describe('Controller', function() {
       controller.onSetEmbedCode('oldEmbedCode');
       controller.onPlaybackReady();
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
-      controller.onPlaying();
+      controller.onInitialPlay();
       controller.onSetEmbedCode('newEmbedCode');
       controller.onPlaybackReady();
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.LOADING_SCREEN);

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -228,18 +228,15 @@ describe('Controller', function() {
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
     });
 
-    it('should show start screen on playback ready for first video', function() {
-      controller.onPlaybackReady();
+    it('should show start screen on playback ready when core reports it will NOT autoplay', function() {
+      expect(controller.state.screenToShow).not.toBe(CONSTANTS.SCREEN.START_SCREEN);
+      controller.onPlaybackReady('event', { willAutoplay: false });
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
     });
 
-    it('should show loading screen on playback ready when switching videos', function() {
-      controller.onSetEmbedCode('oldEmbedCode');
-      controller.onPlaybackReady();
-      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
-      controller.onInitialPlay();
-      controller.onSetEmbedCode('newEmbedCode');
-      controller.onPlaybackReady();
+    it('should show loading screen on playback ready when core reports it will autoplay', function() {
+      expect(controller.state.screenToShow).not.toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
+      controller.onPlaybackReady('event', { willAutoplay: true });
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
     });
 


### PR DESCRIPTION
[Ticket](https://jira.corp.ooyala.com:8443/browse/PLAYER-1270)

This will mostly help improve the UX of transitions between videos for Discovery, Playlists and custom carousels.

The following fixes were implemented:

- The skin will now show a single state between videos (loading screen).
- The progress bar of new videos will now start at 0 (it used to flash a full progress bar for about a second and then reset to 0).
- The skin will no longer flash the replay button when transitioning between playlist videos.
- The skin will no longer flash the big play button for videos that have autoplay enabled.

**This PR needs to be merged after this one:**
https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/290/overview