### PR TITLE
[PBW-6804] Updating shrinkwrap version of deepmerge

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -929,9 +929,9 @@
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
     },
     "deepmerge": {
-      "version": "1.3.0",
-      "from": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.0.tgz",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.3.0.tgz"
+      "version": "1.4.0",
+      "from": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-1.4.0.tgz"
     },
     "git-rev": {
       "version": "0.2.1",


### PR DESCRIPTION
Without this, `npm install` will keep installing the old version of deepmerge