### PR TITLE
[PLAYER-2016] Adding type attribute to all buttons

### DIFF
--- a/js/components/closeButton.js
+++ b/js/components/closeButton.js
@@ -7,6 +7,7 @@ var CloseButton = React.createClass({
   render: function() {
     return (
       <button
+        type="button"
         className={this.props.cssClass}
         onClick={this.props.closeAction}
         onMouseUp={Utils.blurOnMouseUp}

--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -428,7 +428,9 @@ var ControlBar = React.createClass({
 
     var controlItemTemplates = {
       "playPause": (function (alignment) {
-        return <button className="oo-play-pause oo-control-bar-item"
+        return <button
+          type="button"
+          className="oo-play-pause oo-control-bar-item"
           onClick={this.handlePlayClick}
           onMouseUp={Utils.blurOnMouseUp}
           onMouseOver={this.highlight}
@@ -459,7 +461,9 @@ var ControlBar = React.createClass({
 
       "volume": (function (alignment) {
         return <div className="oo-volume oo-control-bar-item" key="volume">
-          <button className="oo-mute-unmute oo-control-bar-item"
+          <button
+            type="button"
+            className="oo-mute-unmute oo-control-bar-item"
             onClick={this.handleVolumeIconClick}
             onMouseUp={Utils.blurOnMouseUp}
             onMouseOver={this.highlight}
@@ -500,6 +504,7 @@ var ControlBar = React.createClass({
       "quality": (function (alignment) {
         return <div className="oo-popover-button-container" key="quality">
           <button
+            type="button"
             ref={function(e) { this.qualityBtnElement = e }.bind(this)}
             className={qualityClass}
             style={selectedStyle}
@@ -564,7 +569,9 @@ var ControlBar = React.createClass({
       "stereoscopic": (function (alignment) {
         var checkStereoBtn = this.vr && this.isMobile;
         return (!checkStereoBtn) ? null :
-          <button className="oo-video-type oo-control-bar-item oo-vr-stereo-button"
+          <button
+            type="button"
+            className="oo-video-type oo-control-bar-item oo-vr-stereo-button"
             onClick={this.handleStereoVrClick}
             onMouseUp={Utils.blurOnMouseUp}
             onMouseOver={this.highlight}
@@ -572,8 +579,7 @@ var ControlBar = React.createClass({
             key="stereo"
             data-focus-id="stereo"
             tabIndex="0"
-            aria-label={stereoAriaLabel}
-          >
+            aria-label={stereoAriaLabel}>
             <Icon {...this.props} icon={stereoIcon} style={dynamicStyles.iconCharacter} />
             <Tooltip enabled={isTooltipEnabled} responsivenessMultiplier={this.responsiveUIMultiple}
               bottom={this.responsiveUIMultiple * this.props.skinConfig.controlBar.height} alignment={alignment} />
@@ -581,7 +587,9 @@ var ControlBar = React.createClass({
       }).bind(this),
 
     "fullscreen": (function (alignment) {
-        return <button className="oo-fullscreen oo-control-bar-item"
+        return <button
+          type="button"
+          className="oo-fullscreen oo-control-bar-item"
           onClick={this.handleFullscreenClick}
           onMouseUp={Utils.blurOnMouseUp}
           onMouseOver={this.highlight}

--- a/js/components/videoQualityPanel.js
+++ b/js/components/videoQualityPanel.js
@@ -125,6 +125,7 @@ var VideoQualityPanel = React.createClass({
     bitrateButtons.unshift(
       <li className="oo-auto-li" key='auto-li' role="presentation">
         <button
+          type="button"
           className={autoQualityBtn}
           key="auto"
           data-focus-id="auto"
@@ -173,6 +174,7 @@ var VideoQualityPanel = React.createClass({
           <li key={i} role="presentation">
             <button
               key={i}
+              type="button"
               className={qualityBtn}
               style={selectedBitrateStyle}
               data-focus-id={'quality' + i}

--- a/js/views/endScreen.js
+++ b/js/views/endScreen.js
@@ -98,7 +98,9 @@ var EndScreen = React.createClass({
           {descriptionMetadata}
         </div>
 
-        <button className={actionIconClass}
+        <button
+          type="button"
+          className={actionIconClass}
           onClick={this.handleClick}
           onMouseUp={Utils.blurOnMouseUp}
           tabIndex="0"

--- a/js/views/pauseScreen.js
+++ b/js/views/pauseScreen.js
@@ -178,7 +178,12 @@ var PauseScreen = React.createClass({
           {this.props.skinConfig.pauseScreen.showDescription ? descriptionMetadata : null}
         </div>
 
-        <button className={actionIconClass} onClick={this.handleClick} aria-hidden="true" tabIndex="-1">
+        <button
+          type="button"
+          className={actionIconClass}
+          onClick={this.handleClick}
+          aria-hidden="true"
+          tabIndex="-1">
           <Icon {...this.props} icon="pause" style={actionIconStyle}/>
         </button>
 

--- a/js/views/startScreen.js
+++ b/js/views/startScreen.js
@@ -114,7 +114,9 @@ var StartScreen = React.createClass({
     // We do not show the action icon, title or description when the player is initializing
     if (!this.props.isInitializing) {
       actionIcon = (
-        <button className={actionIconClass}
+        <button
+          type="button"
+          className={actionIconClass}
           onMouseUp={Utils.blurOnMouseUp}
           onClick={this.handleClick}
           tabIndex="0"


### PR DESCRIPTION
Buttons that don't have a `type` attribute will default to `type="submit"` in some browsers. This will cause issues if the player is contained within a form element.