### PR TITLE
[PLAYER-1270] Adapting to latest mjolnir changes

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -771,7 +771,7 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       }
     },
 
-    onPlaybackReady: function(event, params) {
+    onPlaybackReady: function(event, timeSincePlayerCreated, params) {
       if(this.state.failoverInProgress) {
         return;
       }

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -230,13 +230,13 @@ describe('Controller', function() {
 
     it('should show start screen on playback ready when core reports it will NOT autoplay', function() {
       expect(controller.state.screenToShow).not.toBe(CONSTANTS.SCREEN.START_SCREEN);
-      controller.onPlaybackReady('event', { willAutoplay: false });
+      controller.onPlaybackReady('event', null, { willAutoplay: false });
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
     });
 
     it('should show loading screen on playback ready when core reports it will autoplay', function() {
       expect(controller.state.screenToShow).not.toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
-      controller.onPlaybackReady('event', { willAutoplay: true });
+      controller.onPlaybackReady('event', null, { willAutoplay: true });
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
     });
 


### PR DESCRIPTION
It looks like mjolnir was updated from this:
```
this.mb.publish(OO.EVENTS.PLAYBACK_READY, {
  willAutoplay: this.shouldAutoplay()
});
```
to this: 
```
this.mb.publish(OO.EVENTS.PLAYBACK_READY, timeSincePlayerCreated, {
  willAutoplay: this.shouldAutoplay()
});
```
So this was breaking the changes from PLAYER-1270.

I think we should disallow updates that change the order of parameters in message bus events, since any existing listeners that expect the current order will break. It's probably also a good idea to have all parameters inside an object so that you can easily add new ones without having to worry about the order.