### PR TITLE
[PLAYER-1992] Passing isFullScreen parameter when firing SET_CLOSED_CAPTIONS_LANGUAGE event

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -734,7 +734,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       if (source == OO.VIDEO.MAIN) {
         var language = "";
         var mode = 'disabled';
-        this.mb.publish(OO.EVENTS.SET_CLOSED_CAPTIONS_LANGUAGE, language, {"mode": mode});
+        this.mb.publish(OO.EVENTS.SET_CLOSED_CAPTIONS_LANGUAGE, language, {
+          mode: mode,
+          isFullScreen: this.state.fullscreen
+        });
         this.state.mainVideoDuration = this.state.duration;
       }
     },
@@ -1646,7 +1649,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       }
       var language = this.state.closedCaptionOptions.enabled ? this.state.closedCaptionOptions.language : "";
       var mode = this.state.closedCaptionOptions.enabled ? OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN : OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED;
-      this.mb.publish(OO.EVENTS.SET_CLOSED_CAPTIONS_LANGUAGE, language, {"mode": mode});
+      this.mb.publish(OO.EVENTS.SET_CLOSED_CAPTIONS_LANGUAGE, language, {
+        mode: mode,
+        isFullScreen: this.state.fullscreen
+      });
     },
 
     closeScreen: function() {
@@ -1676,7 +1682,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         var captionLanguage = this.state.closedCaptionOptions.enabled ? language : "";
         var mode = this.state.closedCaptionOptions.enabled ? OO.CONSTANTS.CLOSED_CAPTIONS.HIDDEN : OO.CONSTANTS.CLOSED_CAPTIONS.DISABLED;
         //publish set closed caption event
-        this.mb.publish(OO.EVENTS.SET_CLOSED_CAPTIONS_LANGUAGE, captionLanguage, {"mode": mode});
+        this.mb.publish(OO.EVENTS.SET_CLOSED_CAPTIONS_LANGUAGE, captionLanguage, {
+          mode: mode,
+          isFullScreen: this.state.fullscreen
+        });
         //update skin, save new closed caption language
         this.renderSkin();
         this.mb.publish(OO.EVENTS.SAVE_PLAYER_SETTINGS, this.state.persistentSettings);


### PR DESCRIPTION
This should be merged together with the following PR:
https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/326/overview

The skin triggers `SET_CLOSED_CAPTIONS_LANGUAGE` every time the video resumes playback, so this was causing closed captions to disappear on fullscreen iOS when pausing and then resuming. The core uses the `isFullScreen` parameter to determine whether to show the native closed captions on iOS or not, so this state was being lost.