### PR TITLE
[player-2011]

### DIFF
--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -124,7 +124,6 @@ module.exports = {
     TIME_DISPLAY: MACROS.CURRENT_TIME + " of " + MACROS.TOTAL_TIME,
     TIME_DISPLAY_LIVE: "Live video",
     TIME_DISPLAY_DVR: MACROS.CURRENT_TIME + " of " + MACROS.TOTAL_TIME + " live video",
-    QUALITY_LEVEL: "Quality level " + MACROS.LEVEL + ", " + MACROS.BITRATE,
     CLOSE: "Close",
     TOGGLE_CLOSED_CAPTIONS: "Toggle Closed Captions",
     CAPTION_OPTIONS: "Closed Caption Options",
@@ -279,8 +278,21 @@ module.exports = {
     TEXT: {
       RESOLUTION_BITRATE: MACROS.RESOLUTION + "p (" + MACROS.BITRATE + ")",
       RESOLUTION_ONLY: MACROS.RESOLUTION + "p",
+      TIERED_RESOLUTION_ONLY: MACROS.RESOLUTION + "p (" + MACROS.RESOLUTION_TIER + ")",
       BITRATE_ONLY: MACROS.BITRATE
     }
+  },
+
+  RESOLUTION_TIER: {
+    TWO: [
+      "Low",
+      "High"
+    ],
+    THREE: [
+      "Low",
+      "Medium",
+      "High"
+    ]
   },
 
   ERROR_MESSAGE: {

--- a/js/constants/macros.js
+++ b/js/constants/macros.js
@@ -5,5 +5,6 @@ module.exports = {
   TOTAL_TIME: "{totalTime}",
   LEVEL: "{level}",
   RESOLUTION: "{resolution}",
+  RESOLUTION_TIER: "{resolutionTier}",
   BITRATE: "{bitrate}"
 };


### PR DESCRIPTION
-removed “quality level” aria label for bitrate only video quality selections
-added tiered resolutions for resolution only video quality selections
-moved button creation outside of the render function into a separate function