### PR TITLE
[bugfix/PLAYER-2220]: videoVr should not blur on pause.

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -749,7 +749,11 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
           this.state.screenToShow = CONSTANTS.SCREEN.PAUSE_SCREEN;
         }
         this.state.playerState = CONSTANTS.STATE.PAUSE;
-        this.state.mainVideoElement.classList.add('oo-blur');
+
+        // [PLAYER-2220]: videoVr should not blur. This prevents a circular review on a pause.
+        if (!this.videoVr) {
+          this.state.mainVideoElement.classList.add('oo-blur');
+        }
         this.renderSkin();
       }
       else if (videoId == OO.VIDEO.ADS){

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -387,6 +387,21 @@ describe('Controller', function() {
       spy.restore();
     });
 
+    it('should not be blur when videoVr is paused', function () {
+      var spy = sinon.spy(controller.state.mainVideoElement.classList, 'add');
+      var playerParam = {
+        playerControlsOverAds: false
+      };
+      controller.videoVr = true;
+      controller.state.playerParam = playerParam;
+      controller.createPluginElements();
+
+      controller.onVcPlay('event', OO.VIDEO.MAIN);
+      controller.onPaused('event', OO.VIDEO.MAIN);
+
+      expect(spy.callCount).toBe(0);
+      spy.restore();
+    });
   });
 
   describe('Volume state', function() {


### PR DESCRIPTION
Video 360 should not be blured on pause (videoVr should not blur). This is because even for paused video user is able to look around and this is useless for blured video.
If we have Video360 then we don't set class to blur the player.
Unit tests added.