### PR TITLE
[PLAYER-2672] Sorting video qualities by bitrate when only bitrate is displayed

### DIFF
--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -166,6 +166,31 @@ var Utils = {
   },
 
   /**
+   * Sorts the qualities provided by the BITRATE_INFO_AVAILABLE event in descending
+   * order by bitrate and then by resolution.
+   * @function sortQualitiesByBitrate
+   * @param {Array} qualities The array of qualities in the format provided by the BITRATE_INFO_AVAILABLE event.
+   * @return {Array} A new array with the qualities sorted in descending order by bitrate and then resolution.
+   */
+  sortQualitiesByBitrate: function(qualities) {
+    // Avoid modifying the array that was passed
+    qualities = Array.isArray(qualities) ? qualities.slice() : [];
+    // Sort bitrates by resolution and then by bitrate in descending order
+    qualities.sort(function(a, b) {
+      a = a || {};
+      b = b || {};
+      var bitrateA = this.ensureNumber(a.bitrate, 0);
+      var bitrateB = this.ensureNumber(b.bitrate, 0);
+      var resolutionA = this.ensureNumber(a.width, 1) * this.ensureNumber(a.height, 1);
+      var resolutionB = this.ensureNumber(b.width, 1) * this.ensureNumber(b.height, 1);
+      // When both bitrates are equal the difference will be falsy (zero) and
+      // the second condition (resolution) will be used instead
+      return bitrateB - bitrateA || resolutionB - resolutionA;
+    }.bind(this));
+    return qualities;
+  },
+
+  /**
   * Trims the given text to fit inside of the given element, truncating with ellipsis.
   *
   * @function truncateTextToWidth

--- a/js/controller.js
+++ b/js/controller.js
@@ -1279,6 +1279,14 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
 
     onBitrateInfoAvailable: function(event, bitrates) {
       if (bitrates && bitrates.bitrates) {
+        var qualityFormat = Utils.getPropertyValue(this.skin, 'props.skinConfig.controlBar.qualitySelection.format');
+        // Bitrates will be presorted by the VTC which will work in most cases, however,
+        // when displaying only bitrates we need to give priority to bitrates over
+        // resolutions when sorting, otherwise the quality display might appear unsorted to the user.
+        if (qualityFormat === CONSTANTS.QUALITY_SELECTION.FORMAT.BITRATE) {
+          bitrates.bitrates = Utils.sortQualitiesByBitrate(bitrates.bitrates);
+        }
+
         this.state.videoQualityOptions.availableBitrates = bitrates.bitrates;
         this.renderSkin({
           "videoQualityOptions": {

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -191,6 +191,59 @@ describe('Utils', function () {
 
   });
 
+  describe('sortQualitiesByBitrate', function() {
+
+    it('should gracefully handle invalid input', function() {
+      expect(Array.isArray(Utils.sortQualitiesByBitrate({}))).toBe(true);
+      expect(Array.isArray(Utils.sortQualitiesByBitrate([null, {}, { bitrate: '2000' }]))).toBe(true);
+    });
+
+    it('should sort qualities in descending order by bitrate then resolution', function() {
+      var sourceBitrates = [ // Sorted by resolution by VTC
+        { "id": "4", "width": 320, "height": 180, "bitrate": 1800000 },
+        { "id": "5", "width": 320, "height": 180, "bitrate": 1200000 },
+        { "id": "3", "width": 640, "height": 360, "bitrate": 2500000 },
+        { "id": "2", "width": 640, "height": 360, "bitrate": 3300000 },
+        { "id": "1", "width": 1280, "height": 720, "bitrate": 4400000 },
+        { "id": "auto", "width": 0, "height": 0, "bitrate": 0 }
+      ];
+      var sortedBitrates = [
+        { "id": "1", "width": 1280, "height": 720, "bitrate": 4400000 },
+        { "id": "2", "width": 640, "height": 360, "bitrate": 3300000 },
+        { "id": "3", "width": 640, "height": 360, "bitrate": 2500000 },
+        { "id": "4", "width": 320, "height": 180, "bitrate": 1800000 },
+        { "id": "5", "width": 320, "height": 180, "bitrate": 1200000 },
+        { "id": "auto", "width": 0, "height": 0, "bitrate": 0 }
+      ];
+      expect(Utils.sortQualitiesByBitrate(sourceBitrates)).toEqual(sortedBitrates);
+    });
+
+    it('should give priority to bitrate over resolution when sorting', function() {
+      var sourceBitrates = [ // Sorted by resolution by VTC
+        { "id": "1", "width": 1280, "height": 720, "bitrate": 4400000 },
+        { "id": "2", "width": 640, "height": 360, "bitrate": 3300000 },
+        { "id": "3", "width": 640, "height": 360, "bitrate": 1200000 },
+        { "id": "4", "width": 320, "height": 180, "bitrate": 1800000 },
+        { "id": "5", "width": 320, "height": 180, "bitrate": 1200000 },
+        { "id": "6", "width": 320, "height": 180, "bitrate": 400000 },
+        { "id": "7", "width": 320, "height": 180, "bitrate": 150000 },
+        { "id": "auto", "width": 0, "height": 0, "bitrate": 0 }
+      ];
+      var sortedBitrates = [
+        { "id": "1", "width": 1280, "height": 720, "bitrate": 4400000 },
+        { "id": "2", "width": 640, "height": 360, "bitrate": 3300000 },
+        { "id": "4", "width": 320, "height": 180, "bitrate": 1800000 },
+        { "id": "3", "width": 640, "height": 360, "bitrate": 1200000 },
+        { "id": "5", "width": 320, "height": 180, "bitrate": 1200000 },
+        { "id": "6", "width": 320, "height": 180, "bitrate": 400000 },
+        { "id": "7", "width": 320, "height": 180, "bitrate": 150000 },
+        { "id": "auto", "width": 0, "height": 0, "bitrate": 0 }
+      ];
+      expect(Utils.sortQualitiesByBitrate(sourceBitrates)).toEqual(sortedBitrates);
+    });
+
+  });
+
   it('tests isSafari', function () {
     window.navigator.userAgent = 'AppleWebKit';
     var isSafari = Utils.isSafari();
@@ -311,7 +364,7 @@ describe('Utils', function () {
   });
 
   it('tests getStartCountdown', function () {
-    var text = "6 days, 5 hours, and 14 minutes"; 
+    var text = "6 days, 5 hours, and 14 minutes";
     var countDownText = Utils.getStartCountdown(537289879);
     expect(countDownText).toBe(text);
 

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -578,4 +578,35 @@ describe('Controller', function() {
       expect(controller.state.config.adScreen.showControlBar).toBe(true);
     });
   });
+
+  describe('Video Qualities', function() {
+    var qualities;
+
+    beforeEach(function() {
+      qualities = {
+        bitrates: [
+          { "id": "1", "width": 640, "height": 360, "bitrate": 150000 },
+          { "id": "2", "width": 320, "height": 180, "bitrate": 2500000 },
+          { "id": "auto", "width": 0, "height": 0, "bitrate": 0 }
+        ]
+      };
+    });
+
+    it('should sort qualities by bitrate when quality selection format = bitrate', function() {
+      controller.skin.props.skinConfig.controlBar.qualitySelection.format = CONSTANTS.QUALITY_SELECTION.FORMAT.BITRATE;
+      controller.onBitrateInfoAvailable('event', qualities);
+      expect(controller.state.videoQualityOptions.availableBitrates).toEqual([
+        { "id": "2", "width": 320, "height": 180, "bitrate": 2500000 },
+        { "id": "1", "width": 640, "height": 360, "bitrate": 150000 },
+        { "id": "auto", "width": 0, "height": 0, "bitrate": 0 }
+      ]);
+    });
+
+    it('should NOT sort qualities by bitrate when quality selection format != bitrate', function() {
+      controller.skin.props.skinConfig.controlBar.qualitySelection.format = CONSTANTS.QUALITY_SELECTION.FORMAT.RESOLUTION;
+      controller.onBitrateInfoAvailable('event', qualities);
+      expect(controller.state.videoQualityOptions.availableBitrates).toBe(qualities.bitrates);
+    });
+
+  });
 });


### PR DESCRIPTION
[Ticket](https://jira.corp.ooyala.com/browse/PLAYER-2672)

Bitrates published `BITRATE_INFO_AVAILABLE` will now be presorted, but in the special case where only bitrates are displayed (without resolution) then the skin needs to do some additional sorting in order to display the bitrates in ascending order.

This could've potentially been handled by the VTC as well, but I thought it shouldn't be concerned about display related stuff.

This needs to be merged together with the following PR's:
https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/422/overview