### PR TITLE
[PLAYER-2102] Preventing control bar from flashing during video transitions

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -886,8 +886,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
       if (this.state.afterOoyalaAd) {
         this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
       } else {
-        // If the core tells us that it will autoplay then we just display the loading
-        // spinner, otherwise we need to render the big play button.
+        // If the core tells us that it will autoplay then we display the loading
+        // spinner (with the thumbnail and description if it's the first video, or just a
+        // black background when transitioning to a new one), otherwise we need to render
+        // the big play button.
         if (params.willAutoplay) {
           // Show just the loading spinner when transitioning to another Discovery or
           // Playlist video, otherwise show the spinner and thumbnail.

--- a/js/controller.js
+++ b/js/controller.js
@@ -1622,6 +1622,10 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
           break;
         case CONSTANTS.STATE.PLAYING:
           this.isNewVrVideo = false;
+          // In some cases the controlBarVisible var might get out of sync if not
+          // set explicitly when pausing. When this happens the control bar flashes
+          // when the playingScreen is rendered, so we want to avoid that.
+          this.showControlBar();
           this.mb.publish(OO.EVENTS.PAUSE);
           break;
       }

--- a/js/controller.js
+++ b/js/controller.js
@@ -882,7 +882,13 @@ OO.plugin("Html5Skin", function (OO, _, $, W) {
         // If the core tells us that it will autoplay then we just display the loading
         // spinner, otherwise we need to render the big play button.
         if (params.willAutoplay) {
-          this.state.screenToShow = CONSTANTS.SCREEN.START_LOADING_SCREEN;
+          // Show just the loading spinner when transitioning to another Discovery or
+          // Playlist video, otherwise show the spinner and thumbnail.
+          if (this.state.initialPlayHasOccurred) {
+            this.state.screenToShow = CONSTANTS.SCREEN.LOADING_SCREEN;
+          } else {
+            this.state.screenToShow = CONSTANTS.SCREEN.START_LOADING_SCREEN;
+          }
         } else {
           this.state.screenToShow = CONSTANTS.SCREEN.START_SCREEN;
         }

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -26,7 +26,7 @@ var PlayingScreen = React.createClass({
     this.browserSupportsTouch = this.props.controller.state.browserSupportsTouch;
 
     return {
-      controlBarVisible: true,
+      controlBarVisible: this.props.controller.state.controlBarVisible,
       isVrNotificationHidden: false,
       isVrIconHidden: false,
       timer: null

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -395,7 +395,14 @@ describe('Controller', function() {
       spy.restore();
     });
 
-    it('should not be blur when videoVr is paused', function () {
+    it('should set controlBarVisible to true when video is paused', function() {
+      controller.state.controlBarVisible = false;
+      controller.state.playerState = CONSTANTS.STATE.PLAYING;
+      controller.togglePlayPause();
+      expect(controller.state.controlBarVisible).toBe(true);
+    });
+
+    it('should not be blurred when videoVr is paused', function () {
       var spy = sinon.spy(controller.state.mainVideoElement.classList, 'add');
       var playerParam = {
         playerControlsOverAds: false

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -318,10 +318,18 @@ describe('Controller', function() {
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.START_SCREEN);
     });
 
-    it('should show loading screen on playback ready when core reports it will autoplay', function() {
-      expect(controller.state.screenToShow).not.toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
+    it('should show start loading screen on playback ready when core reports it will autoplay and playback hasn\'t happened before', function() {
+      controller.state.initialPlayHasOccurred = false;
+      expect(controller.state.screenToShow).not.toBe(CONSTANTS.SCREEN.START_LOADING_SCREEN);
       controller.onPlaybackReady('event', null, { willAutoplay: true });
       expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.START_LOADING_SCREEN);
+    });
+
+    it('should show regular loading screen on playback ready when core reports it will autoplay and initial video has already played', function() {
+      controller.state.initialPlayHasOccurred = true;
+      expect(controller.state.screenToShow).not.toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
+      controller.onPlaybackReady('event', null, { willAutoplay: true });
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.LOADING_SCREEN);
     });
 
     it('should reset playhead on embed code changed', function() {

--- a/tests/views/playingScreen-test.js
+++ b/tests/views/playingScreen-test.js
@@ -9,38 +9,45 @@ var PlayingScreen = require('../../js/views/playingScreen');
 var UnmuteIcon = require('../../js/components/unmuteIcon');
 
 describe('PlayingScreen', function () {
+  var mockController, closedCaptionOptions;
   var handleVrPlayerMouseUp = function() {};
-  it('creates a PlayingScreen and checks mouseMove, mouseUp without video360', function () {
-    var isMoved = false
-      , isTouched = false;
-    var mockController = {
-      videoVr: false,
+
+  beforeEach(function() {
+    mockController = {
       state: {
         isMobile: false,
         accessibilityControlsEnabled: false,
+        controlBarVisible: true,
         upNextInfo: {
           showing: false
         },
         volumeState: {
-          muted: false
+          muted: false,
+          mutingForAutoplay: false
         },
         config: {
           isVrAnimationEnabled: {
             vrNotification: true,
             vrIcon: true
-          },
+          }
         }
-      },
-      startHideControlBarTimer: function() {
-        isMoved = true;
-      },
-      onTouched: function() {
-        isTouched = true;
       }
     };
-
-    var closedCaptionOptions = {
+    closedCaptionOptions = {
       cueText: "cue text"
+    };
+  });
+
+  it('creates a PlayingScreen and checks mouseMove, mouseUp without video360', function () {
+    var isMoved = false
+      , isTouched = false;
+
+    mockController.state.videoVr = false;
+    mockController.startHideControlBarTimer = function() {
+      isMoved = true;
+    };
+    mockController.onTouched = function() {
+      isTouched = true;
     };
 
     var handleVrPlayerMouseMove = function() {};
@@ -67,35 +74,17 @@ describe('PlayingScreen', function () {
   it('creates a PlayingScreen and checks mouseDown, mouseUp with video360', function() {
     var isVrDirectionChecked = false;
     var isStartHideControlBarTimer = false;
-    var mockController = {
-      videoVr: true,
-      state: {
-        isMobile: false,
-        accessibilityControlsEnabled: false,
-        upNextInfo: {
-          showing: false
-        },
-        viewingDirection: {yaw: 0, roll: 0, pitch: 0},
-        volumeState: {
-          muted: false
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          },
-        }
-      },
-      startHideControlBarTimer: function () {
-        isStartHideControlBarTimer = true;
-      },
-      checkVrDirection: function() {
-        isVrDirectionChecked = true;
-      },
+
+    mockController.state.videoVr = true;
+    mockController.state.viewingDirection = {yaw: 0, roll: 0, pitch: 0},
+    mockController.startHideControlBarTimer = function () {
+      isStartHideControlBarTimer = true;
     };
-    var closedCaptionOptions = {
-      cueText: "cue text"
+    mockController.checkVrDirection = function() {
+      isVrDirectionChecked = true;
     };
+    mockController.togglePlayPause = function() {};
+
     var handleVrPlayerMouseDown = function() {
       mockController.checkVrDirection();
     };
@@ -133,33 +122,13 @@ describe('PlayingScreen', function () {
   it('creates a PlayingScreen and checks touchEnd', function () {
     var isInHandleTouchEnd = false;
     var clicked = false;
-    var mockController = {
-      videoVr: false,
-      state: {
-        isMobile: true,
-        accessibilityControlsEnabled: false,
-        upNextInfo: {
-          showing: false
-        },
-        volumeState: {
-          muted: false
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          }
-        },
-      },
-      togglePlayPause: function() {
-        clicked = true;
-      },
-      startHideControlBarTimer: function() {}
-    };
 
-    var closedCaptionOptions = {
-      cueText: "cue text"
+    mockController.state.videoVr = false;
+    mockController.state.isMobile = true;
+    mockController.togglePlayPause = function() {
+      clicked = true;
     };
+    mockController.startHideControlBarTimer = function() {};
 
     var handleVrPlayerMouseUp = function() {
       isInHandleTouchEnd = true;
@@ -185,40 +154,18 @@ describe('PlayingScreen', function () {
     var moved = false;
     var clicked = false;
 
-    var mockController = {
-      videoVr: false,
-      state: {
-        isMobile: false,
-        accessibilityControlsEnabled: false,
-        upNextInfo: {
-          showing: false
-        },
-        volumeState: {
-          muted: false
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          },
-        }
-      },
-      startHideControlBarTimer: function() {
-        moved = true;
-      },
-      togglePlayPause: function() {
-        clicked = true;
-      },
-      showControlBar: function() {
-        over = true;
-      },
-      hideControlBar: function() {
-        out = true;
-      }
+    mockController.state.videoVr = false;
+    mockController.startHideControlBarTimer = function() {
+      moved = true;
     };
-
-    var closedCaptionOptions = {
-      cueText: "cue text"
+    mockController.togglePlayPause = function() {
+      clicked = true;
+    };
+    mockController.showControlBar = function() {
+      over = true;
+    };
+    mockController.hideControlBar = function() {
+      out = true;
     };
 
     // Render pause screen into DOM
@@ -252,41 +199,20 @@ describe('PlayingScreen', function () {
     var moved = false;
     var clicked = false;
 
-    var mockController = {
-      videoVr: true,
-      state: {
-        isMobile: false,
-        accessibilityControlsEnabled: false,
-        upNextInfo: {
-          showing: false
-        },
-        viewingDirection: {yaw: 0, roll: 0, pitch: 0},
-        volumeState: {
-          muted: false
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          },
-        }
-      },
-      startHideControlBarTimer: function() {
-        moved = true;
-      },
-      togglePlayPause: function() {
-        clicked = true;
-      },
-      showControlBar: function() {
-        over = true;
-      },
-      hideControlBar: function() {
-        out = true;
-      },
-    };
+    mockController.state.videoVr = true;
+    mockController.state.viewingDirection = {yaw: 0, roll: 0, pitch: 0};
 
-    var closedCaptionOptions = {
-      cueText: "cue text"
+    mockController.startHideControlBarTimer = function() {
+      moved = true;
+    };
+    mockController.togglePlayPause = function() {
+      clicked = true;
+    };
+    mockController.showControlBar = function() {
+      over = true;
+    };
+    mockController.hideControlBar = function() {
+      out = true;
     };
 
     // Render pause screen into DOM
@@ -328,35 +254,16 @@ describe('PlayingScreen', function () {
   it('creates a PlayingScreen and check play&pause', function () {
     var clicked = false;
     var isMouseMove = true;
-    var mockController = {
-      videoVr: true,
-      state: {
-        isMobile: true,
-        isVrMouseDown: false,
-        isMouseMove: false,
-        accessibilityControlsEnabled: false,
-        upNextInfo: {
-          showing: false
-        },
-        volumeState: {
-          muted: false
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          },
-        }
-      },
-      togglePlayPause: function(){
-        clicked = !clicked;
-      },
-      togglePlayPause: function(){ clicked = true},
-      startHideControlBarTimer: function() {},
+
+    mockController.state.videoVr = true;
+    mockController.state.isMobile = true;
+    mockController.state.isVrMouseDown = false;
+    mockController.state.isMouseMove = false;
+    mockController.togglePlayPause = function(){
+      clicked = !clicked;
     };
-    var closedCaptionOptions = {
-      cueText: "cue text"
-    };
+    mockController.startHideControlBarTimer = function() {};
+
     var handleVrPlayerClick = function() {
       isMouseMove = false;
     };
@@ -381,33 +288,11 @@ describe('PlayingScreen', function () {
     var autoHide = false;
     var controlBar = false;
 
-    var mockController = {
-      state: {
-        isMobile: false,
-        accessibilityControlsEnabled: false,
-        upNextInfo: {
-          showing: false
-        },
-        volumeState: {
-          muted: false
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          },
-        }
-      },
-      startHideControlBarTimer: function() {
-        autoHide = true;
-      },
-      showControlBar: function() {
-        controlBar = true;
-      }
+    mockController.startHideControlBarTimer = function() {
+      autoHide = true;
     };
-
-    var closedCaptionOptions = {
-      cueText: "cue text"
+    mockController.showControlBar = function() {
+      controlBar = true;
     };
 
     var DOM = TestUtils.renderIntoDocument(
@@ -426,33 +311,11 @@ describe('PlayingScreen', function () {
     var autoHide = false;
     var controlBar = false;
 
-    var mockController = {
-      state: {
-        isMobile: false,
-        accessibilityControlsEnabled: false,
-        upNextInfo: {
-          showing: false
-        },
-        volumeState: {
-          muted: false
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          },
-        }
-      },
-      startHideControlBarTimer: function() {
-        autoHide = true;
-      },
-      showControlBar: function() {
-        controlBar = true;
-      }
+    mockController.startHideControlBarTimer = function() {
+      autoHide = true;
     };
-
-    var closedCaptionOptions = {
-      cueText: "cue text"
+    mockController.showControlBar = function() {
+      controlBar = true;
     };
 
     var DOM = TestUtils.renderIntoDocument(
@@ -486,32 +349,10 @@ describe('PlayingScreen', function () {
   });
 
   it('tests playing screen componentWill*', function () {
-    var mockController = {
-      state: {
-        isMobile: false,
-        accessibilityControlsEnabled: false,
-        upNextInfo: {
-          showing: false
-        },
-        volumeState: {
-          muted: false
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          },
-        }
-      },
-      startHideControlBarTimer: function() {moved = true},
-      showControlBar: function() {over = true},
-      hideControlBar: function() {out = true},
-      cancelTimer:function() {}
-    };
-
-    var closedCaptionOptions = {
-      cueText: "cue text"
-    };
+    mockController.startHideControlBarTimer = function() { moved = true };
+    mockController.showControlBar = function() { over = true };
+    mockController.hideControlBar = function() { out = true };
+    mockController.cancelTimer = function() {};
 
     var node = document.createElement('div');
     var playScreen = ReactDOM.render(
@@ -538,27 +379,8 @@ describe('PlayingScreen', function () {
   });
 
   it('should display unmute icon when handling muted autoplay', function () {
-    var mockController = {
-      state: {
-        upNextInfo: {
-          showing: false
-        },
-        volumeState: {
-          muted: true,
-          mutingForAutoplay: true
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          },
-        }
-      }
-    };
-
-    var closedCaptionOptions = {
-      cueText: "cue text"
-    };
+    mockController.state.volumeState.muted = true;
+    mockController.state.volumeState.mutingForAutoplay = true;
 
     var DOM = TestUtils.renderIntoDocument(
       <PlayingScreen
@@ -571,27 +393,8 @@ describe('PlayingScreen', function () {
   });
 
   it('should not display unmute icon when not muted', function () {
-    var mockController = {
-      state: {
-        upNextInfo: {
-          showing: false
-        },
-        volumeState: {
-          muted: false,
-          mutingForAutoplay: true
-        },
-        config: {
-          isVrAnimationEnabled: {
-            vrNotification: true,
-            vrIcon: true
-          }
-        }
-      }
-    };
-
-    var closedCaptionOptions = {
-      cueText: "cue text"
-    };
+    mockController.state.volumeState.muted = false;
+    mockController.state.volumeState.mutingForAutoplay = true;
 
     var DOM = TestUtils.renderIntoDocument(
       <PlayingScreen
@@ -601,6 +404,30 @@ describe('PlayingScreen', function () {
       />);
     var unmuteIcons = TestUtils.scryRenderedComponentsWithType(DOM, UnmuteIcon);
     expect(unmuteIcons.length).toBe(0);
+  });
+
+  it('should initialize with control bar state from controller', function () {
+    var DOM, playingScreen;
+
+    mockController.state.controlBarVisible = true;
+    DOM = TestUtils.renderIntoDocument(
+      <PlayingScreen
+        controller={mockController}
+        closedCaptionOptions={{}}
+        handleVrPlayerMouseUp={function(){}} />
+    );
+    playingScreen = TestUtils.findRenderedComponentWithType(DOM, PlayingScreen);
+    expect(playingScreen.state.controlBarVisible).toBe(true);
+
+    mockController.state.controlBarVisible = false;
+    DOM = TestUtils.renderIntoDocument(
+      <PlayingScreen
+        controller={mockController}
+        closedCaptionOptions={{}}
+        handleVrPlayerMouseUp={function(){}} />
+    );
+    playingScreen = TestUtils.findRenderedComponentWithType(DOM, PlayingScreen);
+    expect(playingScreen.state.controlBarVisible).toBe(false);
   });
 
 });


### PR DESCRIPTION
[Ticket](https://jira.corp.ooyala.com/browse/PLAYER-2102)

This will basically just prevent the control bar from flashing briefly when a new Discovery or Playlist video is first shown. These changes also prevent the start screen from flashing during video transitions. This last issue had already been fixed, but was re-introduced recently.

I also refactored some old unit tests in order to avoid re-declaring a large mock object on each separate test.