### PR TITLE
[feat/PLAYER-3234] Hide CC column in new Multi-Audio menu

### DIFF
--- a/js/components/closed-caption-multi-audio-menu/closedCaptionMultiAudioMenu.js
+++ b/js/components/closed-caption-multi-audio-menu/closedCaptionMultiAudioMenu.js
@@ -80,6 +80,7 @@ var ClosedCaptionMultiAudioMenu = React.createClass({
       );
       closedCaptionsCol = (
         <Tab
+          tabClassName="oo-hidden"
           handleClick={this.handleClosedCaptionClick}
           skinConfig={this.props.skinConfig}
           itemsList={closedCaptionList}

--- a/js/components/closed-caption-multi-audio-menu/tab.js
+++ b/js/components/closed-caption-multi-audio-menu/tab.js
@@ -12,7 +12,7 @@ var Tab = React.createClass({
 
   render: function() {
     return (
-      <div className="oo-cc-ma-menu__coll">
+      <div className={classnames("oo-cc-ma-menu__coll", this.props.tabClassName)}>
         <div className="oo-cc-ma-menu__header">{this.props.header}</div>
         <ScrollArea
           className="oo-cc-ma-menu__scrollarea"
@@ -61,6 +61,7 @@ Tab.defaultProps = {
 };
 
 Tab.propTypes = {
+  tabClassName: React.PropTypes.string,
   header: React.PropTypes.string,
   itemsList: React.PropTypes.arrayOf(
     React.PropTypes.shape({


### PR DESCRIPTION
We hide CC column in new Multi-Audio menu for the first release only. 
(When a new design is existed and CC settings are moved to menu as well then CC column will be shown again.)
Old unit tests are passed.
There is no nessaccary to create new tests.