### PR TITLE
Bugfix/player-3314 to master Language selection closes the CC window

### DIFF
--- a/js/components/closed-caption/closedCaptionPopover.js
+++ b/js/components/closed-caption/closedCaptionPopover.js
@@ -19,7 +19,7 @@ var ClosedCaptionPopover = React.createClass({
       this.props.controller.state.closedCaptionOptions.autoFocus = this.moreOptionsBtn.wasTriggeredWithKeyboard();
       this.moreOptionsBtn.wasTriggeredWithKeyboard(false);
     }
-    this.props.controller.toggleScreen(CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN);
+    this.props.controller.toggleScreen(CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN);
     this.handleClose();
   },
 

--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -227,7 +227,7 @@ var ControlBar = React.createClass({
     this.configureMenuAutofocus(CONSTANTS.MENU_OPTIONS.CLOSED_CAPTIONS);
 
     if (this.props.responsiveView === this.props.skinConfig.responsive.breakpoints.xs.id) {
-      this.props.controller.toggleScreen(CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN);
+      this.props.controller.toggleScreen(CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN);
     } else {
       this.togglePopover(CONSTANTS.MENU_OPTIONS.CLOSED_CAPTIONS);
       this.closeOtherPopovers(CONSTANTS.MENU_OPTIONS.CLOSED_CAPTIONS);

--- a/js/components/moreOptionsPanel.js
+++ b/js/components/moreOptionsPanel.js
@@ -28,7 +28,7 @@ var MoreOptionsPanel = React.createClass({
   },
 
   handleClosedCaptionClick: function() {
-    this.props.controller.toggleScreen(CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN);
+    this.props.controller.toggleScreen(CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN);
   },
 
   handleMultiAudioClick: function() {

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -24,7 +24,7 @@ module.exports = {
     MORE_OPTIONS_SCREEN: 'moreOptionsScreen',
     LOADING_SCREEN: 'loadingScreen',
     START_LOADING_SCREEN: 'startLoadingScreen',
-    CLOSEDCAPTION_SCREEN: 'closedCaptionScreen',
+    CLOSED_CAPTION_SCREEN: 'closedCaptionScreen',
     VIDEO_QUALITY_SCREEN: 'videoQualityScreen',
     ERROR_SCREEN: 'errorScreen',
     MULTI_AUDIO_SCREEN: 'multiAudioScreen'

--- a/js/controller.js
+++ b/js/controller.js
@@ -639,7 +639,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
         } else if (this.state.playerState === CONSTANTS.STATE.PLAYING) {
           this.state.screenToShow = CONSTANTS.SCREEN.PLAYING_SCREEN;
         } else if (this.state.playerState === CONSTANTS.STATE.PAUSE &&
-          this.state.screenToShow !== CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN) {
+          this.state.screenToShow !== CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN) {
           this.state.screenToShow = CONSTANTS.SCREEN.PAUSE_SCREEN;
         }
       }

--- a/js/controller.js
+++ b/js/controller.js
@@ -1384,7 +1384,6 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       } else {
         this.state.closedCaptionOptions.cueText = null;
       }
-      this.renderSkin();
     },
 
     onRelatedVideosFetched: function(event, relatedVideos) {

--- a/js/controller.js
+++ b/js/controller.js
@@ -638,7 +638,8 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
           }
         } else if (this.state.playerState === CONSTANTS.STATE.PLAYING) {
           this.state.screenToShow = CONSTANTS.SCREEN.PLAYING_SCREEN;
-        } else if (this.state.playerState === CONSTANTS.STATE.PAUSE) {
+        } else if (this.state.playerState === CONSTANTS.STATE.PAUSE &&
+          this.state.screenToShow !== CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN) {
           this.state.screenToShow = CONSTANTS.SCREEN.PAUSE_SCREEN;
         }
       }
@@ -1388,6 +1389,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       } else {
         this.state.closedCaptionOptions.cueText = null;
       }
+      this.renderSkin();
     },
 
     onRelatedVideosFetched: function(event, relatedVideos) {

--- a/js/skin.js
+++ b/js/skin.js
@@ -397,11 +397,11 @@ var Skin = React.createClass({
           </ContentScreen>
         );
         break;
-      case CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN:
+      case CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN:
         screen = (
           <ContentScreen
             {...this.props}
-            screen={CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN}
+            screen={CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN}
             screenClassName="oo-content-screen oo-content-screen-closed-captions"
             titleText={CONSTANTS.SKIN_TEXT.CC_OPTIONS}
             autoFocus={this.state.closedCaptionOptions.autoFocus}

--- a/js/views/contentScreen.js
+++ b/js/views/contentScreen.js
@@ -41,7 +41,7 @@ var ContentScreen = React.createClass({
 
   render: function() {
     // overlay only for the closed captions screen. Needs to be different than the other screens because of closed caption preview.
-    var closedCaptionOverlay = this.props.screen == CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN ? (
+    var closedCaptionOverlay = this.props.screen == CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN ? (
       <div className="oo-closed-caption-overlay"></div>
     ) :
     null;

--- a/tests/components/closedCaptionPanel-test.js
+++ b/tests/components/closedCaptionPanel-test.js
@@ -70,7 +70,7 @@ describe('ClosedCaptionPanel', function() {
 
     var DOM = TestUtils.renderIntoDocument(
       <ContentScreen
-        screen={CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN}
+        screen={CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN}
         screenClassName="oo-content-screen oo-content-screen-closed-captions"
         titleText={CONSTANTS.SKIN_TEXT.CC_OPTIONS}
         element={<OnOffSwitch controller={mockController} skinConfig={mockSkinConfig} closedCaptionOptions={closedCaptionOptions}/>}
@@ -100,7 +100,7 @@ describe('ClosedCaptionPanel', function() {
 
     var DOM = TestUtils.renderIntoDocument(
       <ContentScreen
-        screen={CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN}
+        screen={CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN}
         screenClassName="oo-content-screen oo-content-screen-closed-captions"
         titleText={CONSTANTS.SKIN_TEXT.CC_OPTIONS}
         element={<OnOffSwitch controller={mockController} skinConfig={mockSkinConfig} closedCaptionOptions={closedCaptionOptions}/>}
@@ -125,7 +125,7 @@ describe('ClosedCaptionPanel', function() {
 
     var DOM = TestUtils.renderIntoDocument(
       <ContentScreen
-        screen={CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN}
+        screen={CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN}
         screenClassName="oo-content-screen oo-content-screen-closed-captions"
         titleText={CONSTANTS.SKIN_TEXT.CC_OPTIONS}
         element={<OnOffSwitch controller={mockController} skinConfig={mockSkinConfig} closedCaptionOptions={closedCaptionOptions}/>}

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -140,6 +140,22 @@ describe('Controller', function() {
       expect(controller.state.closedCaptionOptions.language).toBe('en');
     });
 
+    it('should save closedCaptionScreen when closedCaption screen is open', function() {
+      controller.onPlaying('event', OO.VIDEO.MAIN);
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.PLAYING_SCREEN);
+      expect(controller.state.playerState).toBe(CONSTANTS.STATE.PLAYING);
+      controller.onVideoElementFocus('event', OO.VIDEO.MAIN);
+      controller.pausedCallback = function() {
+        controller.state.screenToShow = CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN;
+      };
+      controller.onPaused('event', OO.VIDEO.MAIN);
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN);
+      controller.onPlayheadTimeChanged('event', 5, 60, 30, null, OO.VIDEO.MAIN);
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN);
+      controller.onClosedCaptionChange('language', 'en');
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN);
+    });
+
   });
 
   describe('Buffering state', function() {

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -146,14 +146,14 @@ describe('Controller', function() {
       expect(controller.state.playerState).toBe(CONSTANTS.STATE.PLAYING);
       controller.onVideoElementFocus('event', OO.VIDEO.MAIN);
       controller.pausedCallback = function() {
-        controller.state.screenToShow = CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN;
+        controller.state.screenToShow = CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN;
       };
       controller.onPaused('event', OO.VIDEO.MAIN);
-      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN);
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN);
       controller.onPlayheadTimeChanged('event', 5, 60, 30, null, OO.VIDEO.MAIN);
-      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN);
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN);
       controller.onClosedCaptionChange('language', 'en');
-      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN);
+      expect(controller.state.screenToShow).toBe(CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN);
     });
 
   });

--- a/tests/skin-test.js
+++ b/tests/skin-test.js
@@ -90,7 +90,7 @@ describe('Skin screenToShow state', function() {
 
   it('tests CLOSED CAPTION SCREEN', function() {
     this.skin.switchComponent({
-      screenToShow: CONSTANTS.SCREEN.CLOSEDCAPTION_SCREEN,
+      screenToShow: CONSTANTS.SCREEN.CLOSED_CAPTION_SCREEN,
       responsiveId: 'md',
       closedCaptionOptions: {
         autoFocus: false


### PR DESCRIPTION
Fix the issue that  window CC is closed after change a language.

CLOSED_CAPTION_SCREEN is used instead of CLOSEDCAPTION_SCREEN in the skin plugin.

No tests are needed.
