### PR TITLE
[bugfix/PLAYER-634] Add error codes constants

### DIFF
--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -388,15 +388,17 @@ module.exports = {
     },
     'device_limit_reached':{
       name: 'OO.ERROR.API.SAS.ERROR.ERROR_DEVICE_LIMIT_REACHED',
-      title: 'DEVICE LIMIT REACHED',
+      title: 'AUTHORIZATION ERROR',
       description: 'Unable to access this content, as the maximum number of devices' + 
-      ' has already been authorized. Error Code 29'
+      ' has already been authorized. Error Code 29',
+      action: 'Please remove one of your authorized devices to enable this device.'
     },
     'non_registered_device':{
       name: 'OO.ERROR.API.SAS.ERROR.ERROR_NON_REGISTERED_DEVICE',
-      title: 'NON REGISTERED DEVICE',
+      title: 'AUTHORIZATION ERROR',
       description: 'Unable to register this device to this account, as the maximum' + 
-      ' number of authorized devices has already been reached. Error Code 22'
+      ' number of authorized devices has already been reached. Error Code 22',
+      action: 'Please remove one of your authorized devices to enable this device.'
     },
     'drm_general_failure':{
       name: 'OO.ERROR.API.SAS.ERROR_DRM_GENERAL_FAILURE',

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -275,6 +275,7 @@ module.exports = {
     DEVICE_ID_TOO_LONG: 'device_id_too_long',
     DEVICE_INVALID_AUTH_TOKEN: 'device_invalid_auth_token',
     DEVICE_LIMIT_REACHED: 'device_limit_reached',
+    NON_REGISTERED_DEVICE: 'non_registered_device',
     DRM_GENERAL_FAILURE: 'drm_general_failure',
     DRM_SERVER_ERROR: 'drm_server_error',
     INVALID_ENTITLEMENTS: 'invalid_entitlements',
@@ -386,9 +387,16 @@ module.exports = {
       description: 'Invalid Ooyala Player token'
     },
     'device_limit_reached':{
-      name: 'OO.ERROR.API.SAS.ERROR.DEVICE_LIMIT_REACHED',
+      name: 'OO.ERROR.API.SAS.ERROR.ERROR_DEVICE_LIMIT_REACHED',
       title: 'DEVICE LIMIT REACHED',
-      description: 'Device limit has been reached'
+      description: 'Unable to access this content, as the maximum number of devices' + 
+      ' has already been authorized. Error Code 29'
+    },
+    'non_registered_device':{
+      name: 'OO.ERROR.API.SAS.ERROR.ERROR_NON_REGISTERED_DEVICE',
+      title: 'NON REGISTERED DEVICE',
+      description: 'Unable to register this device to this account, as the maximum' + 
+      ' number of authorized devices has already been reached. Error Code 22'
     },
     'drm_general_failure':{
       name: 'OO.ERROR.API.SAS.ERROR_DRM_GENERAL_FAILURE',

--- a/js/views/errorScreen.js
+++ b/js/views/errorScreen.js
@@ -1,37 +1,55 @@
 /** ******************************************************************
   ERROR SCREEN
 *********************************************************************/
-var React = require('react'),
-    ClassNames = require('classnames'),
-    CONSTANTS = require('../constants/constants'),
-    Utils = require('../components/utils'),
-    AccessibilityMixin = require('../mixins/accessibilityMixin');
+var React = require('react');
+var ClassNames = require('classnames');
+var CONSTANTS = require('../constants/constants');
+var Utils = require('../components/utils');
+var AccessibilityMixin = require('../mixins/accessibilityMixin');
 
 var ErrorScreen = React.createClass({
   mixins: [AccessibilityMixin],
 
   render: function() {
-    var errorTitle, errorDescription, errorAction;
+    var errorTitle;
+    var errorDescription;
+    var errorAction;
     if (CONSTANTS.ERROR_MESSAGE.hasOwnProperty(this.props.errorCode.code)) {
-
       var errorAction = CONSTANTS.SKIN_TEXT.ERROR_ACTION;
       if (CONSTANTS.ERROR_MESSAGE[this.props.errorCode.code].action) {
         errorAction = CONSTANTS.ERROR_MESSAGE[this.props.errorCode.code].action;
       }
 
-      errorTitle = Utils.getLocalizedString(this.props.language, CONSTANTS.ERROR_MESSAGE[this.props.errorCode.code].title, this.props.localizableStrings);
-      errorDescription = Utils.getLocalizedString(this.props.language, CONSTANTS.ERROR_MESSAGE[this.props.errorCode.code].description, this.props.localizableStrings);
+      errorTitle = Utils.getLocalizedString(
+        this.props.language,
+        CONSTANTS.ERROR_MESSAGE[this.props.errorCode.code].title,
+        this.props.localizableStrings
+      );
+
+      errorDescription = Utils.getLocalizedString(
+        this.props.language,
+        CONSTANTS.ERROR_MESSAGE[this.props.errorCode.code].description,
+        this.props.localizableStrings
+      );
+
       // / TODO - need to make countdown functionality display for all languages
       var startTime = this.props.errorCode.flight_start_time;
-      if (this.props.errorCode.code === CONSTANTS.ERROR_CODE.FUTURE 
-          && this.props.language === CONSTANTS.LANGUAGE.ENGLISH 
-          && startTime != null && !isNaN(startTime)) {
-        errorDescription = 'This video will be available in ' + Utils.getStartCountdown(startTime * 1000 - Date.now());
+      if (
+        this.props.errorCode.code === CONSTANTS.ERROR_CODE.FUTURE &&
+        this.props.language === CONSTANTS.LANGUAGE.ENGLISH &&
+        startTime !== null &&
+        !isNaN(startTime)
+      ) {
+        errorDescription =
+          'This video will be available in ' + Utils.getStartCountdown(startTime * 1000 - Date.now());
       }
       errorAction = Utils.getLocalizedString(this.props.language, errorAction, this.props.localizableStrings);
-    }
-    else {
-      errorDescription = Utils.getLocalizedString(this.props.language, CONSTANTS.SKIN_TEXT.UNKNOWN_ERROR, this.props.localizableStrings);
+    } else {
+      errorDescription = Utils.getLocalizedString(
+        this.props.language,
+        CONSTANTS.SKIN_TEXT.UNKNOWN_ERROR,
+        this.props.localizableStrings
+      );
       errorTitle = null;
       errorAction = null;
     }
@@ -52,6 +70,19 @@ var ErrorScreen = React.createClass({
     );
   }
 });
+
+ErrorScreen.propTypes = {
+  controller: React.PropTypes.shape({
+    state: React.PropTypes.shape({
+      accessibilityControlsEnabled: React.PropTypes.bool.isRequired
+    }).isRequired
+  }).isRequired,
+  errorCode: React.PropTypes.shape({
+    code: React.PropTypes.string
+  }).isRequired,
+  language: React.PropTypes.string,
+  localizableStrings: React.PropTypes.object
+};
 
 ErrorScreen.defaultProps = {
   controller: {

--- a/tests/views/errorScreen-test.js
+++ b/tests/views/errorScreen-test.js
@@ -3,12 +3,30 @@ jest.dontMock('../../js/mixins/accessibilityMixin');
 jest.dontMock('../../js/components/utils');
 jest.dontMock('../../js/constants/constants');
 jest.dontMock('../../js/mixins/accessibilityMixin');
+jest.dontMock('../../js/constants/constants');
 
 var React = require('react');
 var TestUtils = require('react-addons-test-utils');
 var ErrorScreen = require('../../js/views/errorScreen');
 
 describe('ErrorScreen', function() {
+  /**
+   * render ErrorScreen and return elements
+   * @description renders ErrorScreen in DOM and returns title and description elements
+   * @param {*} props - props to render the component with
+   * @returns {{titleElement: Element, descriptionElement: Element}} - elements
+   */
+  function renderComponentAndFind(props) {
+    var component = TestUtils.renderIntoDocument(<ErrorScreen {...props} />);
+    var titleElement = TestUtils.findRenderedDOMComponentWithClass(component, 'oo-error-title');
+    var descriptionElement = TestUtils.findRenderedDOMComponentWithClass(component, 'oo-error-description');
+
+    return {
+      titleElement: titleElement,
+      descriptionElement: descriptionElement
+    };
+  }
+
   it('test error screen with valid error code', function() {
     var errorCode = {
       code: 'network'
@@ -23,5 +41,75 @@ describe('ErrorScreen', function() {
     };
     // Render error screen into DOM
     var DOM = TestUtils.renderIntoDocument(<ErrorScreen errorCode={errorCode} />);
+  });
+
+  describe('when passing error codes into the component', function() {
+    describe('and error code is drm_server_error', function() {
+      var props = {
+        errorCode: { code: 'drm_server_error' },
+        language: 'en',
+        localizableStrings: {
+          en: {
+            'DRM SERVER ERROR': 'DRM SERVER ERROR',
+            'DRM server error': 'DRM server error'
+          }
+        }
+      };
+
+      var elements = renderComponentAndFind(props);
+
+      it('should render correct title, description and action', function() {
+        expect(elements.titleElement.textContent).toEqual('DRM SERVER ERROR');
+        expect(elements.descriptionElement.textContent).toEqual('DRM server error');
+      });
+    });
+
+    describe('and error code is non_registered_device', function() {
+      var props = {
+        errorCode: { code: 'non_registered_device' },
+        language: 'en',
+        localizableStrings: {
+          en: {
+            'NON REGISTERED DEVICE': 'NON REGISTERED DEVICE',
+            // eslint-disable-next-line max-len
+            'Unable to register this device to this account, as the maximum number of authorized devices has already been reached. Error Code 22':
+              'Unable to register this device to this account, as the maximum' +
+              ' number of authorized devices has already been reached. Error Code 22'
+          }
+        }
+      };
+
+      var elements = renderComponentAndFind(props);
+
+      it('should render correct title, description and action', function() {
+        expect(elements.titleElement.textContent).toEqual('NON REGISTERED DEVICE');
+        // eslint-disable-next-line
+        expect(elements.descriptionElement.textContent).toEqual('Unable to register this device to this account, as the maximum number of authorized devices has already been reached. Error Code 22');
+      });
+    });
+
+    describe('and error code is device_limit_reached', function() {
+      var props = {
+        errorCode: { code: 'device_limit_reached' },
+        language: 'en',
+        localizableStrings: {
+          en: {
+            'DEVICE LIMIT REACHED': 'DEVICE LIMIT REACHED',
+            // eslint-disable-next-line max-len
+            'Unable to access this content, as the maximum number of devices has already been authorized. Error Code 29':
+              'Unable to access this content, as the maximum number of devices' +
+              ' has already been authorized. Error Code 29'
+          }
+        }
+      };
+
+      var elements = renderComponentAndFind(props);
+
+      it('should render correct title, description and action', function() {
+        expect(elements.titleElement.textContent).toEqual('DEVICE LIMIT REACHED');
+        // eslint-disable-next-line
+        expect(elements.descriptionElement.textContent).toEqual('Unable to access this content, as the maximum number of devices has already been authorized. Error Code 29');
+      });
+    });
   });
 });

--- a/tests/views/errorScreen-test.js
+++ b/tests/views/errorScreen-test.js
@@ -20,10 +20,12 @@ describe('ErrorScreen', function() {
     var component = TestUtils.renderIntoDocument(<ErrorScreen {...props} />);
     var titleElement = TestUtils.findRenderedDOMComponentWithClass(component, 'oo-error-title');
     var descriptionElement = TestUtils.findRenderedDOMComponentWithClass(component, 'oo-error-description');
+    var actionElement = TestUtils.findRenderedDOMComponentWithClass(component, 'oo-error-action');
 
     return {
       titleElement: titleElement,
-      descriptionElement: descriptionElement
+      descriptionElement: descriptionElement,
+      actionElement: actionElement
     };
   }
 
@@ -70,11 +72,13 @@ describe('ErrorScreen', function() {
         language: 'en',
         localizableStrings: {
           en: {
-            'NON REGISTERED DEVICE': 'NON REGISTERED DEVICE',
+            'AUTHORIZATION ERROR': 'AUTHORIZATION ERROR',
             // eslint-disable-next-line max-len
             'Unable to register this device to this account, as the maximum number of authorized devices has already been reached. Error Code 22':
               'Unable to register this device to this account, as the maximum' +
-              ' number of authorized devices has already been reached. Error Code 22'
+              ' number of authorized devices has already been reached. Error Code 22',
+            'Please remove one of your authorized devices to enable this device.':
+                'Please remove one of your authorized devices to enable this device.'
           }
         }
       };
@@ -82,9 +86,11 @@ describe('ErrorScreen', function() {
       var elements = renderComponentAndFind(props);
 
       it('should render correct title, description and action', function() {
-        expect(elements.titleElement.textContent).toEqual('NON REGISTERED DEVICE');
+        expect(elements.titleElement.textContent).toEqual('AUTHORIZATION ERROR');
         // eslint-disable-next-line
         expect(elements.descriptionElement.textContent).toEqual('Unable to register this device to this account, as the maximum number of authorized devices has already been reached. Error Code 22');
+        // eslint-disable-next-line
+        expect(elements.actionElement.textContent).toEqual('Please remove one of your authorized devices to enable this device.');
       });
     });
 
@@ -94,11 +100,13 @@ describe('ErrorScreen', function() {
         language: 'en',
         localizableStrings: {
           en: {
-            'DEVICE LIMIT REACHED': 'DEVICE LIMIT REACHED',
+            'AUTHORIZATION ERROR': 'AUTHORIZATION ERROR',
             // eslint-disable-next-line max-len
             'Unable to access this content, as the maximum number of devices has already been authorized. Error Code 29':
               'Unable to access this content, as the maximum number of devices' +
-              ' has already been authorized. Error Code 29'
+              ' has already been authorized. Error Code 29',
+            'Please remove one of your authorized devices to enable this device.':
+              'Please remove one of your authorized devices to enable this device.'
           }
         }
       };
@@ -106,9 +114,11 @@ describe('ErrorScreen', function() {
       var elements = renderComponentAndFind(props);
 
       it('should render correct title, description and action', function() {
-        expect(elements.titleElement.textContent).toEqual('DEVICE LIMIT REACHED');
+        expect(elements.titleElement.textContent).toEqual('AUTHORIZATION ERROR');
         // eslint-disable-next-line
         expect(elements.descriptionElement.textContent).toEqual('Unable to access this content, as the maximum number of devices has already been authorized. Error Code 29');
+        // eslint-disable-next-line
+        expect(elements.actionElement.textContent).toEqual('Please remove one of your authorized devices to enable this device.');
       });
     });
   });


### PR DESCRIPTION
Add error codes 22 and 29 to the list.

### Implements
- [PLAYER-634](https://jira.corp.ooyala.com/browse/PLAYER-634)

### Related PRs
- [459](https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/459/overview)
- [309](https://git.corp.ooyala.com/projects/PBW/repos/video-plugins-internal/pull-requests/309/overview)

### Tests
- Unit tests passsed
- added tests for errorScreen as it seems to be the main cornerstone in this case

### Misc
- codestyle
- prop types