### PR TITLE
[bugfix/PLAYER-3296] Add localized headers to CC and MA menus

### DIFF
--- a/js/components/closed-caption-multi-audio-menu/closedCaptionMultiAudioMenu.js
+++ b/js/components/closed-caption-multi-audio-menu/closedCaptionMultiAudioMenu.js
@@ -1,9 +1,12 @@
 var React = require('react');
 var classnames = require('classnames');
+var _ = require('underscore');
+
+var Utils = require('../utils');
+
 var CONSTANTS = require('../../constants/constants');
 var Tab = require('./tab');
 var MultiAudioTab = require('./multiAudioTab');
-var _ = require('underscore');
 
 var ClosedCaptionMultiAudioMenu = React.createClass({
   /**
@@ -78,6 +81,11 @@ var ClosedCaptionMultiAudioMenu = React.createClass({
     ) {
       multiAudioCol = (
         <MultiAudioTab
+          header={Utils.getLocalizedString(
+            this.props.language,
+            CONSTANTS.SKIN_TEXT.AUDIO,
+            this.props.localizableStrings
+          )}
           handleClick={this.handleMultiAudioClick}
           skinConfig={this.props.skinConfig}
           audioTracksList={this.props.controller.state.multiAudio.tracks}
@@ -102,7 +110,11 @@ var ClosedCaptionMultiAudioMenu = React.createClass({
           handleClick={this.handleClosedCaptionClick}
           skinConfig={this.props.skinConfig}
           itemsList={closedCaptionList}
-          header={CONSTANTS.SKIN_TEXT.SUBTITLES}
+          header={Utils.getLocalizedString(
+            this.props.language,
+            CONSTANTS.SKIN_TEXT.SUBTITLES,
+            this.props.localizableStrings
+          )}
         />
       );
     }
@@ -120,6 +132,8 @@ ClosedCaptionMultiAudioMenu.propTypes = {
   menuClassName: React.PropTypes.string,
   skinConfig: React.PropTypes.object,
   togglePopoverAction: React.PropTypes.func,
+  language: React.PropTypes.string,
+  localizableStrings: React.PropTypes.object,
   controller: React.PropTypes.shape({
     setCurrentAudio: React.PropTypes.func,
     onClosedCaptionChange: React.PropTypes.func,

--- a/js/components/closed-caption-multi-audio-menu/multiAudioTab.js
+++ b/js/components/closed-caption-multi-audio-menu/multiAudioTab.js
@@ -32,19 +32,20 @@ var MultiAudioTab = React.createClass({
     var transformedTracksList = helpers.transformTracksList(readableTracksList);
 
     var uniqueTracksList = helpers.getUniqueTracks(transformedTracksList);
-    
+
     return (
       <Tab
         handleClick={this.props.handleClick}
         skinConfig={this.props.skinConfig}
         itemsList={uniqueTracksList}
-        header={CONSTANTS.SKIN_TEXT.AUDIO}
+        header={this.props.header}
       />
     );
   }
 });
 
 MultiAudioTab.propTypes = {
+  header: React.PropTypes.string.isRequired,
   audioTracksList: React.PropTypes.arrayOf(
     React.PropTypes.shape({
       id: React.PropTypes.string.isRequired,

--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -729,6 +729,8 @@ var ControlBar = React.createClass({
               closeAction={this.closePopover.bind(this, CONSTANTS.MENU_OPTIONS.MULTI_AUDIO)}
             >
               <ClosedCaptionMultiAudioMenu
+                language={this.props.language}
+                localizableStrings={this.props.localizableStrings}
                 menuClassName={"oo-cc-ma-menu--popover"}
                 togglePopoverAction={this.closePopover.bind(this, CONSTANTS.MENU_OPTIONS.MULTI_AUDIO)}
                 {...this.props}

--- a/tests/components/closed-caption-multi-audio-menu/closedCaptionMultiAudioMenu-test.js
+++ b/tests/components/closed-caption-multi-audio-menu/closedCaptionMultiAudioMenu-test.js
@@ -2,6 +2,7 @@ jest.dontMock('../../../js/components/closed-caption-multi-audio-menu/closedCapt
 jest.dontMock('../../../js/components/closed-caption-multi-audio-menu/multiAudioTab');
 jest.dontMock('../../../js/components/closed-caption-multi-audio-menu/tab');
 jest.dontMock('../../../js/components/closed-caption-multi-audio-menu/helpers');
+jest.dontMock('../../../js/components/utils');
 jest.dontMock('../../../js/constants/languages');
 jest.dontMock('underscore');
 
@@ -55,6 +56,18 @@ describe('ClosedCaptionMultiAudioMenu component', function() {
             ]
           }
         }
+      },
+      language: 'sp',
+      localizableStrings: {
+        en: {
+          Audio: 'MockTitleEn'
+        },
+        sp: {
+          Audio: 'MockTitleSp'
+        },
+        ja: {
+          Audio: 'MockTitleJa'
+        }
       }
     };
 
@@ -90,6 +103,17 @@ describe('ClosedCaptionMultiAudioMenu component', function() {
       lang: 'eng',
       id: '1'
     });
+  });
+
+  it('should render MultiAudioTab component with translated title', function() {
+    var component = TestUtils.findRenderedComponentWithType(DOM, MultiAudioTab);
+
+    expect(component).toBeTruthy();
+
+    var tabComponent = TestUtils.scryRenderedComponentsWithType(DOM, Tab);
+
+    var header = TestUtils.findRenderedDOMComponentWithClass(tabComponent[0], 'oo-cc-ma-menu__header');
+    expect(header.textContent).toEqual('MockTitleSp');
   });
 
   it('should also render Tab component when options are provided', function() {


### PR DESCRIPTION
Fixes an issue where title from constants was used instead of retrieving localized string.

### Implements
- [PLAYER-3296](https://jira.corp.ooyala.com/browse/PLAYER-3296)

### Tests
- Added a test to verify that string from translations is used in rendering