### PR TITLE
[bugfix/PLAYER-3580] Audio instead of MultiAudio as a text for tooltip

### DIFF
--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -871,7 +871,7 @@ var ControlBar = React.createClass({
                 enabled={isTooltipEnabled}
                 text={Utils.getLocalizedString(
                   this.props.language,
-                  CONSTANTS.SKIN_TEXT.MULTI_AUDIO,
+                  CONSTANTS.SKIN_TEXT.AUDIO,
                   this.props.localizableStrings
                 )}
                 responsivenessMultiplier={this.responsiveUIMultiple}


### PR DESCRIPTION
Use translated "Audio" instead of untranslated "Multi Audio"

[Original task])(https://jira.corp.ooyala.com/browse/PLAYER-3580)

No tests needed