### PR TITLE
[bugfix/PLAYER-3751] Cardboard icon is visible on tablets

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -41,9 +41,10 @@
       }
     ],
     "max-len": [
-      "error", 110, 
+      "error", 110,
       {
-        "ignoreComments": true
+        "ignoreComments": true,
+        "ignorePattern": "if \\(\/\\(\\w*|\\)\/"
       }
     ],
     "no-continue": ["warn"],

--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -19,6 +19,7 @@ var React = require('react'),
 var ControlBar = React.createClass({
   getInitialState: function() {
     this.isMobile = this.props.controller.state.isMobile;
+    this.isPhone = Utils.getUserDevice() === 'phone';
     this.domNode = null;
     this.responsiveUIMultiple = this.getResponsiveUIMultiple(this.props.responsiveView);
     this.moreOptionsItems = null;
@@ -106,7 +107,7 @@ var ControlBar = React.createClass({
     evt.preventDefault();
     if (this.props.controller) {
       this.props.controller.toggleFullscreen();
-      if (this.vr && this.isMobile && this.props.controller.isVrStereo) {
+      if (this.vr && this.isPhone && this.props.controller.isVrStereo) {
         this.toggleStereoVr();
       }
     }
@@ -634,7 +635,10 @@ var ControlBar = React.createClass({
       ),
 
       flexibleSpace: (
-        <div key={CONSTANTS.CONTROL_BAR_KEYS.FLEXIBLE_SPACE} className="oo-flexible-space oo-control-bar-flex-space" />
+        <div
+          key={CONSTANTS.CONTROL_BAR_KEYS.FLEXIBLE_SPACE}
+          className="oo-flexible-space oo-control-bar-flex-space"
+        />
       ),
 
       moreOptions: (
@@ -831,7 +835,7 @@ var ControlBar = React.createClass({
         </a>
       ),
 
-      stereoscopic: !!(this.vr && this.isMobile) && (
+      stereoscopic: !!(this.vr && this.isPhone) && (
         <AccessibleButton
           key={CONSTANTS.CONTROL_BAR_KEYS.STEREOSCOPIC}
           className="oo-video-type oo-control-bar-item oo-vr-stereo-button"

--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -376,6 +376,28 @@ var Utils = {
     return this.isAndroid() || this.isIos();
   },
 
+
+  /**
+   * Get type of user device.
+   *
+   * @returns {string} - name of the user device, may be one of the values 'desktop', 'phone' or 'tablet'.
+   */
+  getUserDevice: function() {
+    var device = 'desktop';
+    var userAgent = navigator.userAgent;
+    if (userAgent) {
+      var lowerUserAgent = userAgent.toLowerCase();
+      if (/(mobi|ipod|phone|blackberry|opera mini|fennec|minimo|symbian|psp|nintendo ds|archos|skyfire|puffin|blazer|bolt|gobrowser|iris|maemo|semc|teashark|uzard)/
+          .test(lowerUserAgent)) {
+        device = 'phone';
+      } else if (/(ipad|tablet|(android(?!.*mobile))|(windows(?!.*phone)(.*touch))|kindle|playbook|silk|(puffin(?!.*(IP|AP|WP))))/
+          .test(lowerUserAgent)) {
+        device = 'tablet';
+      }
+    }
+    return device;
+  },
+
   /**
    * Check if the current browser is Internet Explorer 10
    *
@@ -592,7 +614,9 @@ var Utils = {
     // This is currently the same style as the one used in _mixins.scss.
     // We should change both styles whenever we update this.
     target.style.textShadow =
-      '0px 0px 3px rgba(255, 255, 255, 0.5), 0px 0px 6px rgba(255, 255, 255, 0.5), 0px 0px 9px rgba(255, 255, 255, 0.5)';
+      '0px 0px 3px rgba(255, 255, 255, 0.5), ' +
+      '0px 0px 6px rgba(255, 255, 255, 0.5), ' +
+      '0px 0px 9px rgba(255, 255, 255, 0.5)';
   },
 
   /**

--- a/tests/components/controlBar-test.js
+++ b/tests/components/controlBar-test.js
@@ -129,94 +129,155 @@ describe('ControlBar', function() {
     expect(fullscreenToggled).toBe(true);
   });
 
-  it('render one stereo button if content vr', function() {
-    var mockController = {
-      state: {
-        isMobile: true,
-        volumeState: {
-          volume: 1
+  describe('Vr on phones', function(){
+    beforeEach(function() {
+      window.navigator.userAgent = 'phone';
+    });
+    afterEach(function() {
+      window.navigator.userAgent = 'desktop';
+    });
+
+    it('render one stereo button if content vr', function() {
+      var mockController = {
+        state: {
+          isMobile: true,
+          volumeState: {
+            volume: 1
+          },
+          closedCaptionOptions: {},
+          multiAudioOptions: {},
+          videoQualityOptions: {
+            availableBitrates: null
+          }
         },
-        closedCaptionOptions: {},
-        multiAudioOptions: {},
-        videoQualityOptions: {
-          availableBitrates: null
+        videoVrSource: {
+          vr: {
+            stereo: false,
+            contentType: 'single',
+            startPosition: 0
+          }
         }
-      },
-      videoVrSource: {
-        vr: {
-          stereo: false,
-          contentType: 'single',
-          startPosition: 0
-        }
-      }
-    };
+      };
 
-    var toggleSkinConfig = Utils.clone(skinConfig);
-    toggleSkinConfig.buttons.desktopContent = [{'name':'stereoscopic', 'location':'controlBar', 'whenDoesNotFit':'keep', 'minWidth':35 }];
+      var toggleSkinConfig = Utils.clone(skinConfig);
+      toggleSkinConfig.buttons.desktopContent = [{'name':'stereoscopic', 'location':'controlBar', 'whenDoesNotFit':'keep', 'minWidth':35 }];
 
-    var mockProps = {
-      isLiveStream: false,
-      controller: mockController,
-      skinConfig: toggleSkinConfig,
-      duration: 30,
-      vr: mockController.videoVrSource
-    };
+      var mockProps = {
+        isLiveStream: false,
+        controller: mockController,
+        skinConfig: toggleSkinConfig,
+        duration: 30,
+        vr: mockController.videoVrSource
+      };
 
-    var DOM = TestUtils.renderIntoDocument(
-      <ControlBar {...mockProps} controlBarVisible={true}
-                  componentWidth={500}
-                  playerState={CONSTANTS.STATE.PLAYING}
-                  isLiveStream={mockProps.isLiveStream} />
-    );
+      var DOM = TestUtils.renderIntoDocument(
+        <ControlBar {...mockProps} controlBarVisible={true}
+                    componentWidth={500}
+                    playerState={CONSTANTS.STATE.PLAYING}
+                    isLiveStream={mockProps.isLiveStream} />
+      );
 
-    var toggleStereoVrButton = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-vr-stereo-button');
-    expect(typeof toggleStereoVrButton).toBe('object');
-  });
+      var toggleStereoVrButton = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-vr-stereo-button');
+      expect(toggleStereoVrButton.length).toBe(1);
+    });
 
-  it('not render stereo button if content not vr', function() {
-    var mockController = {
-      state: {
-        isMobile: true,
-        volumeState: {
-          volume: 1
+    it('not render stereo button if content not vr', function() {
+      var mockController = {
+        state: {
+          isMobile: true,
+          volumeState: {
+            volume: 1
+          },
+          closedCaptionOptions: {},
+          multiAudioOptions: {},
+          videoQualityOptions: {
+            availableBitrates: null
+          }
         },
-        closedCaptionOptions: {},
-        multiAudioOptions: {},
-        videoQualityOptions: {
-          availableBitrates: null
+        videoVr: false,
+        videoVrSource: false
+      };
+
+      var toggleSkinConfig = Utils.clone(skinConfig);
+      toggleSkinConfig.buttons.desktopContent = [{'name':'stereoscopic', 'location':'controlBar', 'whenDoesNotFit':'keep', 'minWidth':35 }];
+
+
+      var mockProps = {
+        isLiveStream: false,
+        controller: mockController,
+        skinConfig: toggleSkinConfig,
+        duration: 30,
+        vr: mockController.videoVr
+      };
+
+      var DOM = TestUtils.renderIntoDocument(
+        <ControlBar {...mockProps} controlBarVisible={true}
+                    componentWidth={500}
+                    playerState={CONSTANTS.STATE.PLAYING}
+                    isLiveStream={mockProps.isLiveStream} />
+      );
+
+      var toggleStereoVrButtons = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-vr-stereo-button');
+      expect(toggleStereoVrButtons.length).toBe(0);
+    });
+
+    it('enter stereo mode', function() {
+      var stereoMode = false;
+
+      var mockController = {
+        state: {
+          isMobile: true,
+          volumeState: {
+            volume: 1
+          },
+          closedCaptionOptions: {},
+          multiAudioOptions: {},
+          videoQualityOptions: {
+            availableBitrates: null
+          }
+        },
+        videoVrSource: {
+          vr: {
+            stereo: false,
+            contentType: 'single',
+            startPosition: 0
+          }
+        },
+        toggleStereoVr: function() {
+          stereoMode = true;
         }
-      },
-      videoVr: false,
-      videoVrSource: false
-    };
+      };
 
-    var toggleSkinConfig = Utils.clone(skinConfig);
-    toggleSkinConfig.buttons.desktopContent = [{'name':'stereoscopic', 'location':'controlBar', 'whenDoesNotFit':'keep', 'minWidth':35 }];
+      var toggleSkinConfig = Utils.clone(skinConfig);
+      toggleSkinConfig.buttons.desktopContent = [{'name':'stereoscopic', 'location':'controlBar', 'whenDoesNotFit':'keep', 'minWidth':35 }];
 
+      var mockProps = {
+        isLiveStream: false,
+        controller: mockController,
+        skinConfig: toggleSkinConfig,
+        duration: 30,
+        vr: mockController.videoVrSource
+      };
 
-    var mockProps = {
-      isLiveStream: false,
-      controller: mockController,
-      skinConfig: toggleSkinConfig,
-      duration: 30,
-      vr: mockController.videoVr
-    };
+      var DOM = TestUtils.renderIntoDocument(
+        <ControlBar {...mockProps} controlBarVisible={true}
+                    componentWidth={500}
+                    playerState={CONSTANTS.STATE.PLAYING}
+                    isLiveStream={mockProps.isLiveStream} />
+      );
+      DOM.isPhone = true;
 
-    var DOM = TestUtils.renderIntoDocument(
-      <ControlBar {...mockProps} controlBarVisible={true}
-                  componentWidth={500}
-                  playerState={CONSTANTS.STATE.PLAYING}
-                  isLiveStream={mockProps.isLiveStream} />
-    );
+      expect(stereoMode).toBe(false);
+      var toggleStereoVrButton = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-vr-stereo-button');
+      TestUtils.Simulate.click(toggleStereoVrButton);
+      expect(stereoMode).toBe(true);
+    });
 
-    var toggleStereoVrButtons = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-vr-stereo-button');
-    expect(toggleStereoVrButtons.length).toBe(0);
   });
 
   it('not render stereo button on desktop', function() {
     var mockController = {
       state: {
-        isMobile: false,
         volumeState: {
           volume: 1
         },
@@ -233,7 +294,6 @@ describe('ControlBar', function() {
     var toggleSkinConfig = Utils.clone(skinConfig);
     toggleSkinConfig.buttons.desktopContent = [{'name':'stereoscopic', 'location':'controlBar', 'whenDoesNotFit':'keep', 'minWidth':35 }];
 
-
     var mockProps = {
       isLiveStream: false,
       controller: mockController,
@@ -251,57 +311,6 @@ describe('ControlBar', function() {
 
     var toggleStereoVrButtons = TestUtils.scryRenderedDOMComponentsWithClass(DOM, 'oo-vr-stereo-button');
     expect(toggleStereoVrButtons.length).toBe(0);
-  });
-
-  it('enter stereo mode', function() {
-    var stereoMode = false;
-
-    var mockController = {
-      state: {
-        isMobile: true,
-        volumeState: {
-          volume: 1
-        },
-        closedCaptionOptions: {},
-        multiAudioOptions: {},
-        videoQualityOptions: {
-          availableBitrates: null
-        }
-      },
-      videoVrSource: {
-        vr: {
-          stereo: false,
-          contentType: 'single',
-          startPosition: 0
-        }
-      },
-      toggleStereoVr: function() {
-        stereoMode = true;
-      }
-    };
-
-    var toggleSkinConfig = Utils.clone(skinConfig);
-    toggleSkinConfig.buttons.desktopContent = [{'name':'stereoscopic', 'location':'controlBar', 'whenDoesNotFit':'keep', 'minWidth':35 }];
-
-    var mockProps = {
-      isLiveStream: false,
-      controller: mockController,
-      skinConfig: toggleSkinConfig,
-      duration: 30,
-      vr: mockController.videoVrSource
-    };
-
-    var DOM = TestUtils.renderIntoDocument(
-      <ControlBar {...mockProps} controlBarVisible={true}
-                  componentWidth={500}
-                  playerState={CONSTANTS.STATE.PLAYING}
-                  isLiveStream={mockProps.isLiveStream} />
-    );
-
-    expect(stereoMode).toBe(false);
-    var toggleStereoVrButton = TestUtils.findRenderedDOMComponentWithClass(DOM, 'oo-vr-stereo-button');
-    TestUtils.Simulate.click(toggleStereoVrButton);
-    expect(stereoMode).toBe(true);
   });
 
   it('renders one button', function() {

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -600,4 +600,16 @@ describe('Utils', function() {
     expect(finalConfig.buttons.desktopContent[6].name).toBe('alice');
     expect(finalConfig.buttons.desktopContent[10].alice).toBe('video');
   });
+
+  it('tests getUserDevice', function() {
+    window.navigator.userAgent = 'Phone';
+    var device = Utils.getUserDevice();
+    expect(device).toBe('phone');
+    window.navigator.userAgent = 'Tablet';
+    device = Utils.getUserDevice();
+    expect(device).toBe('tablet');
+    window.navigator.userAgent = 'Webkit';
+    device = Utils.getUserDevice();
+    expect(device).toBe('desktop');
+  });
 });


### PR DESCRIPTION
There is function "isMobile" which checkes if a user device is phones or tablets. And returns true if the device is phone or tablet. But we need to show a carbord icon only on phones (exept tablets).

So now we have function "getUserDevice" for checking type of the user devices ( which returns one of values: phone, tablet or desktop). And if the device is phone we show the icon.

Unit tests are passed.

And there are 2 changes for ESLint (in utils.js line 617 and controlBar.js line 638)