### PR TITLE
[control-bar-test] clone to parse/stringify

### DIFF
--- a/tests/components/controlBar-test.js
+++ b/tests/components/controlBar-test.js
@@ -26,7 +26,7 @@ var _ = require('underscore');
 describe('ControlBar', function() {
 
   var baseMockController, baseMockProps;
-  var defaultSkinConfig = Utils.clone(skinConfig);
+  var defaultSkinConfig = JSON.parse(JSON.stringify(skinConfig));
 
   // The ControlBar is wrapped by the preserveKeyboardFocus higher order component.
   // For some tests it is necessary to reference the inner component directly, so


### PR DESCRIPTION
Way to clone skinConfig for controlBar-test was changed from using an utils function to JSON methods.