### PR TITLE
Player 3808

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": [ "@babel/preset-env", "@babel/preset-react" ]
+  "presets": [ "@babel/preset-env", "@babel/preset-react" ],
+  "plugins": [ "@babel/plugin-proposal-class-properties" ]
 }

--- a/js/views/pauseScreen.js
+++ b/js/views/pauseScreen.js
@@ -16,6 +16,8 @@ var React = require('react'),
     ViewControlsVr = require('../components/viewControlsVr');
 
 class PauseScreen extends React.Component{
+  //Alex: When transitioning to a class, I've removed the usage of mixins since they have been
+  //deprecated. I've brought in the animate and resize mixin functionalities directly into this class.
   constructor(props) {
     super(props);
     this.state = {
@@ -60,18 +62,31 @@ class PauseScreen extends React.Component{
     clearTimeout(this.animateTimer);
   }
 
+  /**
+   * Originally part of the animationMixin. Sets the animate state to true. Used
+   * to animate the fade of the pause button in the center of the screen upon pausing.
+   * @private
+   */
   startAnimation = () => {
     this.setState({
       animate: true
     });
   };
 
+  /**
+   * Show the pause screen by setting the hidden state to false.
+   * @private
+   */
   showPauseScreen = () => {
     this.setState({
       hidden: false
     });
   };
 
+  /**
+   * Hide the pause screen by setting the hidden state to true.
+   * @private
+   */
   hidePauseScreen = () => {
     this.setState({
       hidden: true
@@ -179,16 +194,22 @@ class PauseScreen extends React.Component{
     }
   };
 
+  /**
+   * MouseLeave event handler. Hides the pause screen if the autoHide skin config is set to true.
+   * @private
+   */
   handleMouseLeave = () => {
     if (this.props.skinConfig.pauseScreen.autoHide) {
       this.hidePauseScreen();
     }
   };
 
+  /**
+   * MouseEnter event handler. Shows the pause screen.
+   * @private
+   */
   handleMouseEnter = () => {
-    if (this.props.skinConfig.pauseScreen.autoHide) {
-      this.showPauseScreen();
-    }
+    this.showPauseScreen();
   };
 
   render() {
@@ -309,8 +330,7 @@ class PauseScreen extends React.Component{
           onMouseDown={this.handlePlayerMouseDown}
           onTouchStart={this.handlePlayerMouseDown}
           onMouseUp={this.handlePlayerMouseUp}
-          onTouchEnd={this.handleTouchEnd}
-        />
+          onTouchEnd={this.handleTouchEnd} />
 
         <Watermark
           {...this.props}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -347,6 +347,20 @@
         "@babel/plugin-syntax-async-generators": "7.0.0-beta.51"
       }
     },
+    "@babel/plugin-proposal-class-properties": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.0.0-beta.51.tgz",
+      "integrity": "sha1-tcZi+GKjCs6U/EhHeDex0lX6ON8=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-function-name": "7.0.0-beta.51",
+        "@babel/helper-member-expression-to-functions": "7.0.0-beta.51",
+        "@babel/helper-optimise-call-expression": "7.0.0-beta.51",
+        "@babel/helper-plugin-utils": "7.0.0-beta.51",
+        "@babel/helper-replace-supers": "7.0.0-beta.51",
+        "@babel/plugin-syntax-class-properties": "7.0.0-beta.51"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.0.0-beta.51",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.51.tgz",
@@ -382,6 +396,15 @@
       "version": "7.0.0-beta.51",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.51.tgz",
       "integrity": "sha1-aSGvHcPaD87d4KYQc+7Hl7jKpwc=",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "7.0.0-beta.51"
+      }
+    },
+    "@babel/plugin-syntax-class-properties": {
+      "version": "7.0.0-beta.51",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.0.0-beta.51.tgz",
+      "integrity": "sha1-8Mv28iqHnFk6B+jhQckI4IdwHpE=",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.0.0-beta.51"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.0.0-beta.51",
+    "@babel/plugin-proposal-class-properties": "^7.0.0-beta.51",
     "@babel/preset-env": "^7.0.0-beta.51",
     "@babel/preset-react": "^7.0.0-beta.51",
     "babel-core": "^7.0.0-bridge.0",

--- a/scss/components/_pause-screen.scss
+++ b/scss/components/_pause-screen.scss
@@ -1,9 +1,16 @@
 
 .oo-pause-screen {
+  opacity: 1;
+  @include vendor-prefixes(transition, all 0.5s ease);
 
   .oo-text-track-container.oo-in-background {
     z-index: $zindex-background-captions;
   }
+}
+
+.oo-pause-screen.oo-pause-screen-hidden {
+  opacity: 0;
+  @include vendor-prefixes(transition, all 0.5s ease);
 }
 
 .oo-action-icon-pause {

--- a/tests/views/pauseScreen-test.js
+++ b/tests/views/pauseScreen-test.js
@@ -167,4 +167,57 @@ describe('PauseScreen', function() {
     expect(spy.callCount).toBe(0);
     spy.restore();
   });
+
+  describe('AutoHide', function() {
+    it('hides the pause screen when autoHide is enabled and the mouse leaves the pause screen', function() {
+      mockSkinConfig.pauseScreen.autoHide = true;
+      var wrapper = Enzyme.mount(
+        <PauseScreen
+          skinConfig={mockSkinConfig}
+          controller={mockController}
+          contentTree={mockContentTree}
+          handleVrPlayerClick={() => {}}
+          closedCaptionOptions={{cueText: 'sample text'}}
+          playerState={CONSTANTS.STATE.PAUSE}
+        />
+      );
+      wrapper.simulate('mouseLeave');
+      expect(wrapper.find('.oo-pause-screen-hidden').length).toBe(1);
+    });
+
+    it('shows the pause screen when autoHide is enabled and the mouse enters the pause screen', function() {
+      mockSkinConfig.pauseScreen.autoHide = true;
+      var wrapper = Enzyme.mount(
+        <PauseScreen
+          skinConfig={mockSkinConfig}
+          controller={mockController}
+          contentTree={mockContentTree}
+          handleVrPlayerClick={() => {}}
+          closedCaptionOptions={{cueText: 'sample text'}}
+          playerState={CONSTANTS.STATE.PAUSE}
+        />
+      );
+      wrapper.simulate('mouseLeave');
+      expect(wrapper.find('.oo-pause-screen-hidden').length).toBe(1);
+
+      wrapper.simulate('mouseEnter');
+      expect(wrapper.find('.oo-pause-screen-hidden').length).toBe(0);
+    });
+
+    it('does not hide the pause screen when autoHide is disabled and the mouse leaves the pause screen', function() {
+      mockSkinConfig.pauseScreen.autoHide = false;
+      var wrapper = Enzyme.mount(
+        <PauseScreen
+          skinConfig={mockSkinConfig}
+          controller={mockController}
+          contentTree={mockContentTree}
+          handleVrPlayerClick={() => {}}
+          closedCaptionOptions={{cueText: 'sample text'}}
+          playerState={CONSTANTS.STATE.PAUSE}
+        />
+      );
+      wrapper.simulate('mouseLeave');
+      expect(wrapper.find('.oo-pause-screen-hidden').length).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
-updated PauseScreen component to be a class rather than a function
-added a Babel plugin to support public class fields syntax
-added support for auto hiding pause screens
-removed mixins from PauseScreen during the transition to a class. A post about why here: https://reactjs.org/blog/2016/07/13/mixins-considered-harmful.html