### PR TITLE
[bugfix/PLAYER-3847] Not able to change audio track after failover to subchannel2

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1388,6 +1388,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
         this.state.pluginsElement.removeClass('oo-showing');
         this.state.pluginsClickElement.removeClass('oo-showing');
       }
+      this.state.currentVideoId = source;
     },
 
     closeNonlinearAd: function(event) {

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -286,9 +286,11 @@ describe('Controller', function() {
       expect(stopBufferingTimerSpy.callCount).toBe(3);
       expect(controller.state.bufferingTimer).toBeTruthy();
       this.focusedElement = OO.VIDEO.ADS;
+      controller.state.currentVideoId = OO.VIDEO.REPLAY;
       controller.onVideoElementFocus('', OO.VIDEO.MAIN);
       expect(stopBufferingTimerSpy.callCount).toBe(4);
       expect(controller.state.bufferingTimer).toBeFalsy();
+      expect(controller.state.currentVideoId).toBe(OO.VIDEO.MAIN);
       // PLAYED
       controller.startBufferingTimer();
       expect(stopBufferingTimerSpy.callCount).toBe(5);


### PR DESCRIPTION
Now we have a situation for HA video: when second subchannel starts playing function '_removeFocusFromElement' is called; videoId is 'reload' now. After that function 'vcFocusVideoElement' is called, and videoId is becoming 'main', and it is last time when Object { main: {…}, reload: {…} } exists. After that the object is { main: {…} }, but in skin state 'currentVideoId' (which we use for setting audio) is still 'reload'. And when user click on a track from MA list we return from the function because Object['reload'] does not exist.

So, now we change value of currentVideoId in skin to value of videoId in mjolnir.

In the test we check if the value of currentVideoId is correct. 