### PR TITLE
[PLAYER-3645] Allowing UI to react to API speed changes

### DIFF
--- a/js/components/playbackSpeedPanel.js
+++ b/js/components/playbackSpeedPanel.js
@@ -43,12 +43,10 @@ class PlaybackSpeedPanel extends React.Component {
       );
       // Constrain to min and max values and ensure at most 2 decimals
       this.playbackSpeedOptions = this.playbackSpeedOptions.map(option =>
-        Utils.constrainToRange(
-          Utils.toFixedNumber(option, 2),
-          CONSTANTS.PLAYBACK_SPEED.MIN,
-          CONSTANTS.PLAYBACK_SPEED.MAX
-        )
+        Utils.sanitizePlaybackSpeed(option)
       );
+      // Remove duplicates
+      this.playbackSpeedOptions = Utils.dedupeArray(this.playbackSpeedOptions);
       // Sort in ascending order
       this.playbackSpeedOptions.sort((a, b) => a - b);
     }

--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -235,6 +235,50 @@ var Utils = {
   },
 
   /**
+   * Ensures that the given value is a valid playback speed by doing the following:
+   * - Defaulting to 1 for unparseable values
+   * - Constraining to max and min allowed playback speeds (done by default, but can be disabled)
+   * - Truncating to at most two decimals
+   * @private
+   * @param {*} playbackSpeed The playback speed value that we want to sanitize
+   * @param {Boolean} ignoreMinMax Will not constrain to minimum and maximum values when true
+   * @return {Number} A number which is the sanitized version of the value provided
+   */
+  sanitizePlaybackSpeed: function(playbackSpeed, ignoreMinMax) {
+    let sanitizedSpeed = this.ensureNumber(
+      playbackSpeed,
+      CONSTANTS.PLAYBACK_SPEED.DEFAULT_VALUE
+    );
+    if (!ignoreMinMax) {
+      // TODO:
+      // Read values from OO.CONSTANTS once these are available in html5-common
+      sanitizedSpeed = this.constrainToRange(
+        sanitizedSpeed,
+        CONSTANTS.PLAYBACK_SPEED.MIN,
+        CONSTANTS.PLAYBACK_SPEED.MAX
+      );
+    }
+    sanitizedSpeed = Utils.toFixedNumber(sanitizedSpeed, 2);
+    return sanitizedSpeed;
+  },
+
+  /**
+   * Removes duplicate values from an array.
+   * @private
+   * @param {Array} array The array that we want to dedupe
+   * @return {Array} A new array that contains only the unique values from the array parameter
+   */
+  dedupeArray: function(array) {
+    if (!Array.isArray(array)) {
+      return [];
+    }
+    var result = array.filter(function(element, index, array) {
+      return array.indexOf(element) === index;
+    });
+    return result;
+  },
+
+  /**
    * Determines whether a mouse cursor represented by its clientX and clientY
    * properties is inside a DOM element contained within the given DOMRect.
    * @function isMouseInsideRect

--- a/js/controller.js
+++ b/js/controller.js
@@ -731,7 +731,22 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
      * @param {Number} playbackSpeed A number that represents the new playback rate
      */
     onPlaybackSpeedChanged: function(eventName, videoId, playbackSpeed) {
-      playbackSpeed = Utils.ensureNumber(playbackSpeed, 1);
+      // Note that we don't constrain to min/max values in this case since
+      // the new speed is already set, but we make sure that the value we get can
+      // be displayed in a user-friendly way
+      playbackSpeed = Utils.sanitizePlaybackSpeed(playbackSpeed, true);
+      // Add speed to options if it's not one of the predefined values
+      var playbackSpeedOptions = Utils.getPropertyValue(
+        this.skin,
+        'props.skinConfig.playbackSpeed.options'
+      );
+      if (
+        playbackSpeedOptions &&
+        playbackSpeedOptions.indexOf(playbackSpeed) < 0
+      ) {
+        playbackSpeedOptions.push(playbackSpeed);
+      }
+      // Store new current speed and update UI
       this.state.playbackSpeedOptions.currentSpeed = playbackSpeed;
       this.renderSkin();
     },


### PR DESCRIPTION
These updates allow handling the case in which playback speed is set via API to a value that is not one of the predefined values. The UI will now update and include the new value in the list.

Note: Unit tests are still pending, will add in a future PR.