### PR TITLE
[bugfix/PLAYER-4018] langauge code 'und' is translated to 'qafaraf' instead of 'undefined langauge'

### DIFF
--- a/js/components/closed-caption-multi-audio-menu/helpers.js
+++ b/js/components/closed-caption-multi-audio-menu/helpers.js
@@ -35,7 +35,7 @@ function getDisplayLabel(audioTrack) {
 function getDisplayLanguage(languagesList, languageCode) {
   var displayLanguage = '';
   if (
-    typeof languageCode !== 'undefined' &&
+    !!Utils.isValidString(languageCode) &&
     languagesList &&
     _.isArray(languagesList) &&
     languagesList.length

--- a/tests/components/closed-caption-multi-audio-menu/helpers-test.js
+++ b/tests/components/closed-caption-multi-audio-menu/helpers-test.js
@@ -33,6 +33,8 @@ describe('closed caption & multi-audio helpers', function() {
       expect(helpers.getDisplayLanguage([], 'w00t')).toEqual('');
       expect(helpers.getDisplayLanguage([], 'und')).toEqual('');
       expect(helpers.getDisplayLanguage([], null)).toEqual('');
+      expect(helpers.getDisplayLanguage([], '')).toEqual('');
+      expect(helpers.getDisplayLanguage([], false)).toEqual('');
     });
 
     it('should return matched english equivalent', function() {


### PR DESCRIPTION
If we get langCode === '' we should not use it to find name in the language map ; we need to set displayLanguage to ''.

[Origin task](https://jira.corp.ooyala.com:8443/browse/PLAYER-4018)

Unit tests are passed.