### PR TITLE
[PLAYER-3645] Highlighting Playback Speed button when menu is active

### DIFF
--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -401,19 +401,20 @@ var ControlBar = createReactClass({
 
     var qualityClass = ClassNames({
       'oo-quality': true,
-      'oo-control-bar-item': true,
       'oo-selected': this.props.controller.state.videoQualityOptions.showPopover
     });
 
     var captionClass = ClassNames({
       'oo-closed-caption': true,
-      'oo-control-bar-item': true,
       'oo-selected': this.props.controller.state.closedCaptionOptions.showPopover
+    });
+
+    var playbackSpeedClass = ClassNames({
+      'oo-selected': this.props.controller.state.playbackSpeedOptions.showPopover
     });
 
     var multiAudioClass = ClassNames({
       'oo-multiaudio': true,
-      'oo-control-bar-item': true,
       'oo-selected': this.props.controller.state.multiAudioOptions.showPopover
     });
 
@@ -643,6 +644,8 @@ var ControlBar = createReactClass({
           <PlaybackSpeedButton
             {...commonButtonProps}
             onRef={this.setToggleButtons.bind(this, CONSTANTS.MENU_OPTIONS.PLAYBACK_SPEED)}
+            className={playbackSpeedClass}
+            style={this.props.controller.state.playbackSpeedOptions.showPopover ? selectedStyle : null}
             focusId={CONSTANTS.CONTROL_BAR_KEYS.PLAYBACK_SPEED}
             ariaHasPopup={true}
             ariaExpanded={this.props.controller.state.playbackSpeedOptions.showPopover ? true : null}

--- a/tests/components/controlBar-test.js
+++ b/tests/components/controlBar-test.js
@@ -1336,6 +1336,21 @@ describe('ControlBar', function() {
     expect(wrapper.find('.oo-playback-speed').hostNodes().length).toBe(0);
   });
 
+  it('should set selected class on playback speed button when popover is active', function() {
+    baseMockProps.skinConfig.general.accentColor = '#0000ff';
+    baseMockProps.controller.state.playbackSpeedOptions.showPopover = true;
+    baseMockProps.skinConfig.buttons.desktopContent = [
+      { name: 'playbackSpeed', location: 'controlBar', whenDoesNotFit: 'moveToMoreOptions', minWidth: 35 }
+    ];
+    var wrapper = Enzyme.mount(
+      <ControlBar {...baseMockProps} />
+    );
+    expect(wrapper.find(PlaybackSpeedButton).props().className).toBe('oo-selected');
+    expect(wrapper.find(PlaybackSpeedButton).props().style).toEqual({
+      color: baseMockProps.skinConfig.general.accentColor
+    });
+  });
+
   it('hides quality button if ooyala ad is playing', function() {
     baseMockController.state.isOoyalaAds = true;
 


### PR DESCRIPTION
I had missed this little detail. The control bar buttons get the highlight color when their respective popover menu is open.