### PR TITLE
[player-4080]

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1097,7 +1097,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
         // if param hideMultiAudioIcon is set to false
         if (typeof multiAudio !== 'undefined') {
           let multiAudioValue = null;
-          if (multiAudio.tracks) {
+          if (this.containsMultiAudio(multiAudio)) {
             multiAudioValue = { tracks: multiAudio.tracks };
           }
           this.state.multiAudio = multiAudioValue;
@@ -1116,9 +1116,23 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
      */
     onMultiAudioChanged: function(event, multiAudio) {
       if (!this.state.hideMultiAudioIcon) {
-        this.state.multiAudio = multiAudio;
+        if (this.containsMultiAudio(multiAudio)) {
+          this.state.multiAudio = multiAudio;
+        } else {
+          this.state.multiAudio = null;
+        }
+
         this.renderSkin();
       }
+    },
+
+    /**
+     * Checks to see if we have multiple audio tracks
+     * @param multiAudio The multiAudio object that is fetched from the current video
+     * @returns {boolean} True if the provided object contains more than one track, false otherwise
+     */
+    containsMultiAudio: function(multiAudio) {
+      return !!(multiAudio && multiAudio.tracks && multiAudio.tracks.length > 1);
     },
 
     /**

--- a/js/controller.js
+++ b/js/controller.js
@@ -1128,11 +1128,12 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
 
     /**
      * Checks to see if we have multiple audio tracks
-     * @param multiAudio The multiAudio object that is fetched from the current video
+     * @param {Object} multiAudio The multiAudio object that is fetched from the current video
      * @returns {boolean} True if the provided object contains more than one track, false otherwise
      */
     containsMultiAudio: function(multiAudio) {
-      return !!(multiAudio && multiAudio.tracks && multiAudio.tracks.length > 1);
+      var hasMoreThanOneTrack = !!(multiAudio && multiAudio.tracks && multiAudio.tracks.length > 1);
+      return hasMoreThanOneTrack;
     },
 
     /**

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -905,6 +905,41 @@ describe('Controller', function() {
       expect(controller.state.multiAudio).toBe(null);
       controller.onMultiAudioFetched('eventName', multiAudio);
       expect(controller.state.multiAudio).toEqual(multiAudio);
+
+      multiAudio = {
+        tracks: []
+      };
+      controller.onMultiAudioFetched('eventName', multiAudio);
+      expect(controller.state.multiAudio).toBe(null);
+    });
+
+    it('should not set multiAudio state if there are less than 2 tracks', function() {
+      var multiAudio = {
+        tracks: []
+      };
+
+      controller.state.multiAudio = null;
+      expect(controller.state.multiAudio).toBe(null);
+      controller.onMultiAudioFetched('eventName', multiAudio);
+      expect(controller.state.multiAudio).toBe(null);
+
+      multiAudio = {
+        tracks: [
+          { id: '0', kind: 'main', label: 'eng', lang: 'eng', enabled: true }
+        ]
+      };
+
+      controller.state.multiAudio = null;
+      expect(controller.state.multiAudio).toBe(null);
+      controller.onMultiAudioFetched('eventName', multiAudio);
+      expect(controller.state.multiAudio).toBe(null);
+
+      multiAudio = {};
+
+      controller.state.multiAudio = null;
+      expect(controller.state.multiAudio).toBe(null);
+      controller.onMultiAudioFetched('eventName', multiAudio);
+      expect(controller.state.multiAudio).toBe(null);
     });
 
     it('MultiAudio State should be null after embed code was changed', function() {
@@ -915,7 +950,7 @@ describe('Controller', function() {
       expect(controller.languageList).toEqual([]);
 
       controller.onMultiAudioFetched('event', obj2);
-      expect(controller.state.multiAudio).toEqual({tracks: obj2.tracks});
+      expect(controller.state.multiAudio).toBe(null);
       expect(controller.languageList).toEqual(obj2.languageList);
 
       controller.onEmbedCodeChanged('newEmbedCode');
@@ -1006,6 +1041,33 @@ describe('Controller', function() {
       };
       controller.onMultiAudioChanged('event', multiAudio);
       expect(controller.state.multiAudio.tracks).toEqual(multiAudio.tracks);
+
+      multiAudio = {
+        tracks: []
+      };
+      controller.onMultiAudioChanged('event', multiAudio);
+      expect(controller.state.multiAudio).toBe(null);
+    });
+
+    it('should not change multiAudio state if MULTI_AUDIO_CHANGED was called was less than 2 tracks', function() {
+      var multiAudio = {
+        tracks: []
+      };
+      controller.state.multiAudio = null;
+      controller.onMultiAudioChanged('event', multiAudio);
+      expect(controller.state.multiAudio).toBe(null);
+
+      multiAudio = {
+        tracks: [
+          { id: '0', kind: 'main', label: 'eng', lang: 'eng', enabled: true }
+        ]
+      };
+      controller.onMultiAudioChanged('event', multiAudio);
+      expect(controller.state.multiAudio).toBe(null);
+
+      multiAudio = {};
+      controller.onMultiAudioChanged('event', multiAudio);
+      expect(controller.state.multiAudio).toBe(null);
     });
 
     it('should set correct state after MULTI_AUDIO_CHANGED after MULTI_AUDIO_FETCHED was already called', function() {


### PR DESCRIPTION
-will set multiAudio state to null if we receive less than 2 tracks (effectively hiding the multi audio icon)

PLAYER-4080 was occurring because the video element is throwing an audio change event on a single audio track, which sends out a multi audio changed event with only 1 audio track. This makes our skin show the multi audio icon. This looks to be a native Safari issue. To workaround this, I've modified the skin to set the multi audio state to null if we receive a multi audio changed event with less than 2 tracks.