### PR TITLE
bf/PLAYER-3750 View direction is reset to initial position after AD for tilting

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -475,16 +475,16 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
      * Uses for video 360 on mobile devices for setting necessary coordinates (relevant with start device orientation)
      * Before playing this.vrMobileOrientationChecked is equal false,
      * if need to check value for device orientation set this.checkDeviceOrientation = true
-     * @param {object} e The event object
+     * @param {object} event The event object
      */
-    handleVrMobileOrientation: function(e) {
+    handleVrMobileOrientation: function(event) {
       if (!this.vrMobileOrientationChecked || this.checkDeviceOrientation) {
-        var beta = e.beta;
-        var gamma = e.gamma;
-        var yaw = this.state.vrViewingDirection['yaw'];
-        var pitch = this.state.vrViewingDirection['pitch'];
-        var dir = beta;
-        var orientationType = Utils.getOrientationType();
+        let beta = event.beta;
+        let gamma = event.gamma;
+        let yaw = this.state.vrViewingDirection['yaw'];
+        let pitch = this.state.vrViewingDirection['pitch'];
+        let dir = beta;
+        let orientationType = Utils.getOrientationType();
         if (
           orientationType &&
           (orientationType === 'landscape-secondary' || orientationType === 'landscape-primary')
@@ -492,8 +492,9 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
           dir = gamma;
         }
         if (dir !== undefined && dir !== null && Utils.ensureNumber(dir, 0)) {
-          pitch += -90 + Math.abs(Math.round(dir));
-          var params = [yaw, 0, pitch];
+          let halfAngle = 90; // in degrees
+          pitch += -halfAngle + Math.abs(Math.round(dir));
+          let params = [yaw, 0, pitch];
           this.onTouchMove(params);
         }
         this.checkDeviceOrientation = false;
@@ -1062,9 +1063,14 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       }
     },
 
-    checkVrDirection: function() {
+    /**
+     * Get current vr viewing directions
+     * @param {boolean} useVrViewingDirection flag says to use function 'getVrViewingDirection' from the plugin
+     * @fires OO.EVENTS.CHECK_VR_DIRECTION
+     */
+    checkVrDirection: function(useVrViewingDirection) {
       if (this.videoVr) {
-        this.mb.publish(OO.EVENTS.CHECK_VR_DIRECTION, this.focusedElement);
+        this.mb.publish(OO.EVENTS.CHECK_VR_DIRECTION, this.focusedElement, useVrViewingDirection);
       }
     },
 
@@ -1313,6 +1319,15 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       this.trySetAnamorphicFixState(true);
       // In case ad was skipped or errored while stalled
       this.setBufferingState(false);
+
+
+      var vrViewingDirectionList = [
+        this.state.vrViewingDirection.yaw,
+        this.state.vrViewingDirection.roll,
+        this.state.vrViewingDirection.pitch
+      ]; // just for vr
+      this.onTouchMove(vrViewingDirectionList); // just for vr
+
       this.renderSkin();
     },
 
@@ -1332,6 +1347,9 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
         this.isNewVrVideo = false;
       }
       this.state.adPausedTime = 0;
+
+      let useVrViewingDirection = true; //just for vr
+      this.checkVrDirection(useVrViewingDirection); //just for vr
     },
 
     onAdPodStarted: function(event, numberOfAds) {
@@ -1663,7 +1681,9 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       //'auto' prior to the 'click' event ending will trigger 'click' event listeners on Android. We'll instead listen to
       //'touchend' and 'touchcancel' on Android.
       if (OO.isAndroid) {
-        this.state.pluginsClickElement.on('touchend touchcancel', this.resumePlaybackAfterClickthrough.bind(this));
+        this.state.pluginsClickElement.on('touchend touchcancel',
+          this.resumePlaybackAfterClickthrough.bind(this)
+        );
       } else {
         this.state.pluginsClickElement.click(this.resumePlaybackAfterClickthrough.bind(this));
       }
@@ -1691,7 +1711,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
      * was handled by the player.
      * @private
      */
-    resumePlaybackAfterClickthrough: function () {
+    resumePlaybackAfterClickthrough: function() {
       this.state.pluginsClickElement.removeClass('oo-showing');
       this.mb.publish(OO.EVENTS.PLAY);
     },

--- a/js/controller.js
+++ b/js/controller.js
@@ -479,9 +479,9 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
      */
     handleVrMobileOrientation: function(event) {
       if (!this.vrMobileOrientationChecked || this.checkDeviceOrientation) {
-        let beta = event.beta;
-        let gamma = event.gamma;
-        let yaw = this.state.vrViewingDirection['yaw'];
+        const beta = event.beta;
+        const gamma = event.gamma;
+        const yaw = this.state.vrViewingDirection['yaw'];
         let pitch = this.state.vrViewingDirection['pitch'];
         let dir = beta;
         let orientationType = Utils.getOrientationType();
@@ -492,7 +492,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
           dir = gamma;
         }
         if (dir !== undefined && dir !== null && Utils.ensureNumber(dir, 0)) {
-          let halfAngle = 90; // in degrees
+          const halfAngle = 90; // in degrees
           pitch += -halfAngle + Math.abs(Math.round(dir));
           let params = [yaw, 0, pitch];
           this.onTouchMove(params);
@@ -1320,13 +1320,15 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       // In case ad was skipped or errored while stalled
       this.setBufferingState(false);
 
-
-      var vrViewingDirectionList = [
-        this.state.vrViewingDirection.yaw,
-        this.state.vrViewingDirection.roll,
-        this.state.vrViewingDirection.pitch
-      ]; // just for vr
-      this.onTouchMove(vrViewingDirectionList); // just for vr
+      if (this.videoVr && this.state.isMobile) { // only for vr on mobile
+        // Set current position for video 360 after Ads.
+        var vrViewingDirectionList = [
+          this.state.vrViewingDirection.yaw,
+          this.state.vrViewingDirection.roll,
+          this.state.vrViewingDirection.pitch
+        ];
+        this.onTouchMove(vrViewingDirectionList);
+      }
 
       this.renderSkin();
     },
@@ -1348,8 +1350,12 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       }
       this.state.adPausedTime = 0;
 
-      let useVrViewingDirection = true; //just for vr
-      this.checkVrDirection(useVrViewingDirection); //just for vr
+      if (this.videoVr && this.state.isMobile) { // only for vr on mobile
+        // Check current a vr video position (an user could change position using tilting)
+        // for setting this value after Ads in onAdsPlayed
+        const useVrViewingDirection = true;
+        this.checkVrDirection(useVrViewingDirection);
+      }
     },
 
     onAdPodStarted: function(event, numberOfAds) {

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -1417,7 +1417,6 @@ describe('Controller', function() {
       controller.createPluginElements();
 
       let focusedElement = OO.VIDEO.MAIN;
-      OO.isIos = true;
       controller.focusedElement = focusedElement;
       let vrViewingDirection = {
         yaw: 90,
@@ -1425,6 +1424,7 @@ describe('Controller', function() {
         pitch: 90
       };
       controller.state.vrViewingDirection = vrViewingDirection;
+      controller.state.isMobile = true;
 
       controller.onWillPlayAds();
       controller.onAdsPlayed();

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -1402,4 +1402,37 @@ describe('Controller', function() {
       expect(controller.state.pluginsClickElement.hasClass('oo-showing')).toEqual(false);
     });
   });
+
+  describe('Vr functionality', function() {
+    let spy;
+    beforeEach(function() {
+      controller.videoVr = true;
+      spy = sinon.spy(controller.mb, 'publish');
+    });
+    afterEach(function() {
+      controller.videoVr = false;
+      spy.restore();
+    });
+    it('should check viewing directions(before Ads starts play) and set viewing directions(after Ads)', function() {
+      controller.createPluginElements();
+
+      let focusedElement = OO.VIDEO.MAIN;
+      OO.isIos = true;
+      controller.focusedElement = focusedElement;
+      let vrViewingDirection = {
+        yaw: 90,
+        roll: 60,
+        pitch: 90
+      };
+      controller.state.vrViewingDirection = vrViewingDirection;
+
+      controller.onWillPlayAds();
+      controller.onAdsPlayed();
+
+      expect(spy.calledWith(OO.EVENTS.CHECK_VR_DIRECTION, focusedElement, true)).toBe(true);
+      expect(spy.calledWith(OO.EVENTS.TOUCH_MOVE, focusedElement,
+        [ vrViewingDirection.yaw, vrViewingDirection.roll, vrViewingDirection.pitch ]
+      )).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
When an user use only tilting we do not have correct value for viewing direction. So we forcibly check the viewing direction when AD starts and set this value when AD ends.

(And some changes for eslint.)

Unit tests are passed.