### PR TITLE
[bugfix/PLAYER-4226] Page is scrolled when user tries to navigate the video by touch&drag

### DIFF
--- a/js/views/pauseScreen.js
+++ b/js/views/pauseScreen.js
@@ -45,7 +45,7 @@ class PauseScreen extends React.Component {
     this.handleResize();
     this.hideVrPauseButton();
     document.addEventListener('mousemove', this.handlePlayerMouseMove, false);
-    document.addEventListener('touchmove', this.handlePlayerMouseMove, false);
+    document.addEventListener('touchmove', this.handlePlayerMouseMove, { passive: false });
     document.addEventListener('mouseup', this.props.handleVrPlayerMouseUp, false);
     document.addEventListener('touchend', this.props.handleVrPlayerMouseUp, false);
   }

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -52,7 +52,7 @@ class PlayingScreen extends React.Component {
 
   componentDidMount() {
     document.addEventListener('mousemove', this.handlePlayerMouseMove, false);
-    document.addEventListener('touchmove', this.handlePlayerMouseMove, false);
+    document.addEventListener('touchmove', this.handlePlayerMouseMove, { passive: false });
     document.addEventListener('mouseup', this.props.handleVrPlayerMouseUp, false);
     document.addEventListener('touchend', this.props.handleVrPlayerMouseUp, false);
 


### PR DESCRIPTION
Page was scrolled when user tried to navigate the video 360 via touch&drag in window mode.

Document touch event listeners are now passive by default in Safari 11.1, which is bundled with iOS 11.3 (this change is documented in the [Safari 11.1](https://developer.apple.com/library/archive/releasenotes/General/WhatsNewInSafari/Articles/Safari_11_1.html) ) so because of that preventDefault in the callback did not work to prevent scrolling.

Tests are not needed.