### PR TITLE
bugfix/PLAYER-3966 View direciton is not reset to initial from the first time via on-screen contorl

### DIFF
--- a/js/components/directionControlVr.js
+++ b/js/components/directionControlVr.js
@@ -1,32 +1,36 @@
-var React = require('react');
-var classnames = require('classnames');
-var createReactClass = require('create-react-class');
-var PropTypes = require('prop-types');
+const React = require('react');
+const classnames = require('classnames');
+const PropTypes = require('prop-types');
 
-var DirectionControlVr = createReactClass({
-  getInitialState: function() {
-    return {
+/**
+ * A vr video rotation control button
+ */
+class DirectionControlVr extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       isTouched: false
     };
-  },
+    this.rotateVrVideo = this.rotateVrVideo.bind(this);
+  };
 
-  handleEvent: function(ev) {
-    var isRotated = ev.type === 'mousedown' || ev.type === 'touchstart';
-
-    // The call always happens, except for the mouse movement without pressing the mouse button
-    if (this.state.isTouched || ev.type !== 'mouseout') {
-      this.props.handleVrViewControlsClick(ev, isRotated, this.props.dir);
-    }
+  /**
+   * Rotate the image in the specified direction or stop the rotation if the user has stopped clicking on the item
+   * @param {Event} event - event object
+   */
+  rotateVrVideo(event) {
+    const isRotated = event && (event.type === 'mousedown' || event.type === 'touchstart');
+    this.props.handleVrViewControlsClick(event, isRotated, this.props.dir);
 
     this.setState({
       isTouched: isRotated
     });
-  },
+  };
 
-  render: function() {
-    var baseDirectionClass = 'oo-vr-icon--move';
-    var directionClass = baseDirectionClass + '--' + this.props.dir;
-    var touchedDirectionClass = '';
+  render() {
+    const baseDirectionClass = 'oo-vr-icon--move';
+    const directionClass = baseDirectionClass + '--' + this.props.dir;
+    let touchedDirectionClass = '';
     if (this.state.isTouched) {
       touchedDirectionClass = directionClass + '--touched';
     }
@@ -39,18 +43,18 @@ var DirectionControlVr = createReactClass({
           touchedDirectionClass
         )}
         key={this.props.dir}
-        onMouseDown={this.handleEvent}
-        onTouchStart={this.handleEvent}
-        onMouseUp={this.handleEvent}
-        onTouchEnd={this.handleEvent}
-        onMouseOut={this.handleEvent}
+        onMouseDown={this.rotateVrVideo}
+        onTouchStart={this.rotateVrVideo}
+        onMouseUp={this.rotateVrVideo}
+        onTouchEnd={this.rotateVrVideo}
+        onMouseOut={this.rotateVrVideo}
       />
     );
   }
-});
+};
 
 DirectionControlVr.propTypes = {
   handleVrViewControlsClick: PropTypes.func
 };
 
-module.exports = DirectionControlVr;
+export { DirectionControlVr };

--- a/js/components/directionControlVr.js
+++ b/js/components/directionControlVr.js
@@ -20,11 +20,13 @@ class DirectionControlVr extends React.Component {
    */
   rotateVrVideo(event) {
     const isRotated = event && (event.type === 'mousedown' || event.type === 'touchstart');
-    this.props.handleVrViewControlsClick(event, isRotated, this.props.dir);
+    if ((!this.state.isTouched && isRotated) || (this.state.isTouched && !isRotated)) {
+      this.props.handleVrViewControlsClick(event, isRotated, this.props.dir);
 
-    this.setState({
-      isTouched: isRotated
-    });
+      this.setState({
+        isTouched: isRotated
+      });
+    }
   };
 
   render() {

--- a/js/components/viewControlsVr.js
+++ b/js/components/viewControlsVr.js
@@ -1,23 +1,24 @@
 var React = require('react');
-var DirectionControlVr = require('./directionControlVr');
 var Icon = require('../components/icon');
 var classnames = require('classnames');
 var _ = require('underscore');
 var createReactClass = require('create-react-class');
 var PropTypes = require('prop-types');
 
+import { DirectionControlVr } from './directionControlVr';
+
 var ViewControlsVr = createReactClass({
   /**
    * @method ViewControlsVr#handleVrViewControlsClick
    * @public
-   * @param {Event} e - event
+   * @param {Event} event - event object
    * @param {boolean} isRotated - true - if need to rotate; false - stop rotation
    * @param {string} direction - direction for rotation: "left", "right", "up", "down"
    */
-  handleVrViewControlsClick: function(e, isRotated, direction) {
-    if (e.type === 'touchend' || !this.props.controller.state.isMobile) {
-      e.stopPropagation(); // W3C
-      e.cancelBubble = true; // IE
+  handleVrViewControlsClick: function(event, isRotated, direction) {
+    if (event.type === 'touchend' || !this.props.controller.state.isMobile) {
+      event.stopPropagation(); // W3C
+      event.cancelBubble = true; // IE
       this.props.controller.state.accessibilityControlsEnabled = true;
     }
 

--- a/js/components/viewControlsVr.js
+++ b/js/components/viewControlsVr.js
@@ -18,7 +18,6 @@ var ViewControlsVr = createReactClass({
   handleVrViewControlsClick: function(event, isRotated, direction) {
     if (event.type === 'touchend' || !this.props.controller.state.isMobile) {
       event.stopPropagation(); // W3C
-      event.cancelBubble = true; // IE
       this.props.controller.state.accessibilityControlsEnabled = true;
     }
 

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -79,11 +79,12 @@ class PlayingScreen extends React.Component {
    */
   handleVrAnimationEnd(ref, stateName) {
     if (ref) {
+      const _this = this;
       ref.addEventListener('animationend', function _animationEndHandler(stateName) {
         if (stateName) {
           let newState = {};
           newState[stateName] = true;
-          this.setState(newState);
+          _this.setState(newState);
         }
         ref.removeEventListener('animationend', _animationEndHandler, false);
       }, false);

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -79,15 +79,15 @@ class PlayingScreen extends React.Component {
    */
   handleVrAnimationEnd(ref, stateName) {
     if (ref) {
-      const _this = this;
-      ref.addEventListener('animationend', function _animationEndHandler(stateName) {
+      const _animationEndHandler = () => {
         if (stateName) {
           let newState = {};
           newState[stateName] = true;
-          _this.setState(newState);
+          this.setState(newState);
         }
         ref.removeEventListener('animationend', _animationEndHandler, false);
-      }, false);
+      };
+      ref.addEventListener('animationend', _animationEndHandler, false);
     }
   }
 

--- a/tests/components/directionControlVr-test.js
+++ b/tests/components/directionControlVr-test.js
@@ -3,27 +3,50 @@ jest
   .dontMock('../../js/constants/constants')
   .dontMock('classnames');
 
-var React = require('react');
-var Enzyme = require('enzyme');
-var skinConfig = require('../../config/skin.json');
-var CONSTANTS = require('../../js/constants/constants');
+const React = require('react');
+const Enzyme = require('enzyme');
+const skinConfig = require('../../config/skin.json');
+const CONSTANTS = require('../../js/constants/constants');
+const sinon = require('sinon');
+
 import { DirectionControlVr } from '../../js/components/directionControlVr';
 
 describe('directionControlVr', function() {
+  let spyClick;
+  let mockProps = {
+    skinConfig: skinConfig,
+    playerState: CONSTANTS.STATE.PLAYING,
+    clickButton: false,
+    handleVrViewControlsClick: function() {
+      mockProps.clickButton = true;
+    }
+  };
+  beforeEach(function() {
+    spyClick = sinon.spy(mockProps, 'handleVrViewControlsClick');
+  });
+  afterEach(function() {
+    spyClick.restore();
+  });
   it('should creates a directionControlVr', function() {
-    var mockProps = {
-      skinConfig: skinConfig,
-      playerState: CONSTANTS.STATE.PLAYING,
-      clickButton: false,
-      handleVrViewControlsClick: function() {
-        mockProps.clickButton = true;
-      }
-    };
-    var wrapper = Enzyme.mount(<DirectionControlVr {...mockProps}/>);
-    var button = wrapper.find('.oo-direction-control');
+    const wrapper = Enzyme.mount(<DirectionControlVr {...mockProps}/>);
+    const button = wrapper.find('.oo-direction-control');
 
     expect(mockProps.clickButton).toBe(false);
     button.simulate('mouseDown');
     expect(mockProps.clickButton).toBe(true);
+  });
+  it('should call handleVrViewControlsClick with specific params when it is neccessary', function() {
+    mockProps.dir = 'left';
+    const wrapper = Enzyme.mount(<DirectionControlVr {...mockProps}/>);
+    const button = wrapper.find('.oo-direction-control');
+
+    button.simulate('mousedown');
+    expect(spyClick.callCount).toBe(1);
+    expect(spyClick.firstCall.args[1]).toBe(true);
+    button.simulate('mouseup');
+    expect(spyClick.callCount).toBe(2); // should call handleVrViewControlsClick
+    expect(spyClick.secondCall.args[1]).toBe(false);
+    button.simulate('mouseout');
+    expect(spyClick.callCount).toBe(2); // should not call handleVrViewControlsClick
   });
 });

--- a/tests/components/directionControlVr-test.js
+++ b/tests/components/directionControlVr-test.js
@@ -7,7 +7,7 @@ var React = require('react');
 var Enzyme = require('enzyme');
 var skinConfig = require('../../config/skin.json');
 var CONSTANTS = require('../../js/constants/constants');
-var DirectionControlVr = require('../../js/components/directionControlVr');
+import { DirectionControlVr } from '../../js/components/directionControlVr';
 
 describe('directionControlVr', function() {
   it('should creates a directionControlVr', function() {

--- a/tests/components/viewControlsVr-test.js
+++ b/tests/components/viewControlsVr-test.js
@@ -13,8 +13,9 @@ var Enzyme = require('enzyme');
 var skinConfig = require('../../config/skin.json');
 var CONSTANTS = require('../../js/constants/constants');
 var ViewControlsVr = require('../../js/components/viewControlsVr');
-var DirectionControlVr = require('../../js/components/directionControlVr');
 var _ = require('underscore');
+
+import { DirectionControlVr } from '../../js/components/directionControlVr';
 
 describe('viewControlsVr', function() {
   


### PR DESCRIPTION
Prevent dowble call rotation method.
Move to es6 syntax.

The [associated PR](https://git.corp.ooyala.com/projects/PBW/repos/video-plugins-internal/pull-requests/350)

Unit tests passed.
