### PR TITLE
[PLAYER-4428] Removing debug page styles from skin CSS

### DIFF
--- a/scss/html5-skin.scss
+++ b/scss/html5-skin.scss
@@ -69,14 +69,3 @@
   // Skin
   @import "skin/default";
 }
-
-//override non-responsive css on debug.ooyala.com
-//remove this after test site updated
-#video_container {
-  display: inline !important;
-  margin: 0 !important;
-}
-#ooplayer {
-  width:auto !important;
-  height:auto !important;
-}


### PR DESCRIPTION
These styles were only meant for the debug page and can cause conflicts if customers have elements with the `video_container` id, for example. 

**IMPORTANT**
Before deploying this to candidate we need to merge this PR and deploy the debug page changes:

https://git.corp.ooyala.com/projects/PBW/repos/hack_attack/pull-requests/13/overview