### PR TITLE
[PLAYER-4542] Controls look too big on mobile devices

### DIFF
--- a/js/skin.js
+++ b/js/skin.js
@@ -706,7 +706,7 @@ const Skin = createReactClass({
       }
     }
 
-    var className = ClassNames('oo-responsive', {
+    var className = ClassNames(this.state.responsiveClass, 'oo-responsive', {
       'oo-audio-only': this.props.controller.state.audioOnly
     });
 


### PR DESCRIPTION
This branch contains the fix for restore the `responsiveClass` state at skin.js. Also mixes it with the `.oo-responsive` class.