### PR TITLE
[PLAYER-4385] Now reacting to playerType page-level param

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1638,7 +1638,17 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       var uiLanguage = Utils.getLanguageToUse(this.state.config);
       this.mb.publish(OO.EVENTS.SKIN_UI_LANGUAGE, uiLanguage);
 
-      this.state.audioOnly = this.state.config.audio.audioOnly;
+      // Check for valid player type, otherwise default to video
+      switch(params.playerType) {
+        case OO.CONSTANTS.PLAYER_TYPE.AUDIO:
+          this.state.audioOnly = true;
+          break;
+        case OO.CONSTANTS.PLAYER_TYPE.VIDEO:
+        default:
+          this.state.audioOnly = false;
+          break;
+      }
+
       this.state.enableChromecast = this.isChromecastEnabled(params);
 
       // load player

--- a/js/controller.js
+++ b/js/controller.js
@@ -1638,17 +1638,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       var uiLanguage = Utils.getLanguageToUse(this.state.config);
       this.mb.publish(OO.EVENTS.SKIN_UI_LANGUAGE, uiLanguage);
 
-      // Check for valid player type, otherwise default to video
-      switch (params.playerType) {
-        case OO.CONSTANTS.PLAYER_TYPE.AUDIO:
-          this.state.audioOnly = true;
-          break;
-        case OO.CONSTANTS.PLAYER_TYPE.VIDEO:
-        default:
-          this.state.audioOnly = false;
-          break;
-      }
-
+      this.state.audioOnly = params.playerType === OO.CONSTANTS.PLAYER_TYPE.AUDIO;
       this.state.enableChromecast = this.isChromecastEnabled(params);
 
       // load player

--- a/js/controller.js
+++ b/js/controller.js
@@ -1639,7 +1639,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       this.mb.publish(OO.EVENTS.SKIN_UI_LANGUAGE, uiLanguage);
 
       // Check for valid player type, otherwise default to video
-      switch(params.playerType) {
+      switch (params.playerType) {
         case OO.CONSTANTS.PLAYER_TYPE.AUDIO:
           this.state.audioOnly = true;
           break;

--- a/tests/components/controlBar-test.js
+++ b/tests/components/controlBar-test.js
@@ -522,6 +522,8 @@ describe('ControlBar', function() {
         {...baseMockProps}
         controlBarVisible={true}
         componentWidth={500}
+        totalTime={"60:00"}
+        playheadTime={"00:00"}
         playerState={CONSTANTS.STATE.PLAYING} />
     );
     var ccButton = wrapper.find('.oo-closed-caption');
@@ -1287,14 +1289,14 @@ describe('ControlBar', function() {
     it('Should not show chromecast button when player param not exist', () => {
       var wrapper = Enzyme.mount(getControlBar());
       var chromecastBtn = wrapper.find(".oo-cast");
-      expect(chromecastBtn.length).toBe(0); 
+      expect(chromecastBtn.length).toBe(0);
     });
 
     it('Should not show chromecast button when player param not exist', () => {
       baseMockController.state.enableChromecast = true;
       var wrapper = Enzyme.mount(getControlBar());
       var chromecastBtn = wrapper.find(".oo-cast");
-      expect(chromecastBtn.length).toBe(1); 
+      expect(chromecastBtn.length).toBe(1);
     });
   });
 });

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -43,6 +43,10 @@ OO = {
     SKIN_UI_LANGUAGE: 'skinUiLanguage'
   },
   CONSTANTS: {
+    PLAYER_TYPE: {
+      VIDEO: 'video',
+      AUDIO: 'audio',
+    },
     CLOSED_CAPTIONS: {
       HIDDEN: 'hidden',
       SHOWING: 'showing',
@@ -1475,26 +1479,37 @@ describe('Controller', function() {
   });
 
   describe('Audio only', () => {
+
+    it('should set the correct audioOnly value depending on player type', () => {
+      expect(controller.state.audioOnly).toBe(false);
+      controller.loadConfigData({
+        playerType: OO.CONSTANTS.PLAYER_TYPE.AUDIO
+      }, {}, {}, {}, {});
+      expect(controller.state.audioOnly).toBe(true);
+      controller.loadConfigData({
+        playerType: OO.CONSTANTS.PLAYER_TYPE.VIDEO
+      }, {}, {}, {}, {});
+      expect(controller.state.audioOnly).toBe(false);
+      controller.state.audioOnly = true;
+      // No player type specified
+      controller.loadConfigData({}, {}, {}, {}, {});
+      expect(controller.state.audioOnly).toBe(false);
+    });
+
     it('adds oo-video-player class to the video container when not audio only and removes it when audio only', () => {
-      controller.loadConfigData('customerUi', {
-        audio: {
-          audioOnly: true
-        }
-      }, {}, {}, {});
+      controller.loadConfigData({
+        playerType: OO.CONSTANTS.PLAYER_TYPE.AUDIO
+      }, {}, {}, {}, {});
       expect(controller.state.mainVideoInnerWrapper.hasClass('oo-video-player')).toBe(false);
 
-      controller.loadConfigData('customerUi', {
-        audio: {
-          audioOnly: false
-        }
-      }, {}, {}, {});
+      controller.loadConfigData({
+        playerType: OO.CONSTANTS.PLAYER_TYPE.VIDEO
+      }, {}, {}, {}, {});
       expect(controller.state.mainVideoInnerWrapper.hasClass('oo-video-player')).toBe(true);
 
-      controller.loadConfigData('customerUi', {
-        audio: {
-          audioOnly: true
-        }
-      }, {}, {}, {});
+      controller.loadConfigData({
+        playerType: OO.CONSTANTS.PLAYER_TYPE.AUDIO
+      }, {}, {}, {}, {});
       expect(controller.state.mainVideoInnerWrapper.hasClass('oo-video-player')).toBe(false);
     });
 
@@ -1533,11 +1548,9 @@ describe('Controller', function() {
     });
 
     it('does not hide the control bar if player is audio only', () => {
-      controller.loadConfigData('customerUi', {
-        audio: {
-          audioOnly: true
-        }
-      }, {}, {}, {});
+      controller.loadConfigData({
+        playerType: OO.CONSTANTS.PLAYER_TYPE.AUDIO
+      }, {}, {}, {}, {});
 
       controller.startHideControlBarTimer();
       expect(controller.state.timer).toBeFalsy();
@@ -1564,11 +1577,9 @@ describe('Controller', function() {
       controller.state.mainVideoContainer.height = (h) => {
         height = h;
       };
-      controller.loadConfigData('customerUi', {
-        audio: {
-          audioOnly: true
-        }
-      }, {}, {}, {});
+      controller.loadConfigData({
+        playerType: OO.CONSTANTS.PLAYER_TYPE.AUDIO
+      }, {}, {}, {}, {});
 
       expect(height).toBe(CONSTANTS.UI.AUDIO_ONLY_DEFAULT_HEIGHT);
       controller.state.mainVideoContainer.height = originalHeightFunc;


### PR DESCRIPTION
The player will now use the `playerType` page-level param in order enter audio-only mode instead of the `audioOnly` value from the skin.