### PR TITLE
[PLAYER-4582] Disabling Skip Forward button when at video end

### DIFF
--- a/js/components/higher-order/holdOnClick.js
+++ b/js/components/higher-order/holdOnClick.js
@@ -38,6 +38,16 @@ const holdOnClick = function(ComposedComponent) {
     }
 
     /**
+     * Make sure to release click when button is disabled.
+     * @private
+     */
+    componentDidUpdate() {
+      if (this.props.disabled) {
+        this.releaseClick();
+      }
+    }
+
+    /**
      * Handler for the keydown event. Calls the onClick handler for Enter and
      * Space keys. Note that the keydown event has the "hold down to continue triggering"
      * behavior that we want by default, so there's not need to use timers when using the keyboard.

--- a/js/components/skipControls.js
+++ b/js/components/skipControls.js
@@ -18,7 +18,7 @@ class SkipControls extends React.Component {
     this.onNextVideo = this.onNextVideo.bind(this);
     this.onSkipBackward = this.onSkipBackward.bind(this);
     this.onSkipForward = this.onSkipForward.bind(this);
-    this.isAtVideoEnd = this.isAtVideoEnd.bind(this);
+    this.isAtVideoEdge = this.isAtVideoEdge.bind(this);
     this.onMouseEnter = this.onMouseEnter.bind(this);
     this.onPlayPauseClick = this.onPlayPauseClick.bind(this);
   }
@@ -103,22 +103,22 @@ class SkipControls extends React.Component {
    * @private
    * @return {Boolean} True if the video is at the video end/live edge, false otherwise.
    */
-  isAtVideoEnd() {
+  isAtVideoEdge() {
     const isLiveStream = Utils.getPropertyValue(
       this.props.controller,
       'state.isLiveStream',
       false
     );
-    let isVideoEnd = false;
+    let isVideoEdge = false;
     const duration = Utils.getPropertyValue(this.props.controller, 'state.duration', 0);
     const currentPlayhead = Utils.ensureNumber(this.props.currentPlayhead, 0);
 
     if (isLiveStream) {
-      isVideoEnd = Math.abs(currentPlayhead - duration) < 1;
+      isVideoEdge = Math.abs(currentPlayhead - duration) < 1;
     } else {
-      isVideoEnd = currentPlayhead >= duration;
+      isVideoEdge = currentPlayhead >= duration;
     }
-    return isVideoEnd;
+    return isVideoEdge;
   }
 
   /**
@@ -199,7 +199,7 @@ class SkipControls extends React.Component {
         className="oo-center-button oo-skip-forward"
         icon="forward"
         ariaLabel={skipForwardAriaLabel}
-        disabled={this.isAtVideoEnd() || !duration}
+        disabled={this.isAtVideoEdge() || !duration}
         onClick={this.onSkipForward}>
         <span className="oo-btn-counter">{skipTimes.forward}</span>
       </HoldControlButton>

--- a/js/components/skipControls.js
+++ b/js/components/skipControls.js
@@ -18,7 +18,7 @@ class SkipControls extends React.Component {
     this.onNextVideo = this.onNextVideo.bind(this);
     this.onSkipBackward = this.onSkipBackward.bind(this);
     this.onSkipForward = this.onSkipForward.bind(this);
-    this.isAtLiveEdge = this.isAtLiveEdge.bind(this);
+    this.isAtVideoEnd = this.isAtVideoEnd.bind(this);
     this.onMouseEnter = this.onMouseEnter.bind(this);
     this.onPlayPauseClick = this.onPlayPauseClick.bind(this);
   }
@@ -98,25 +98,27 @@ class SkipControls extends React.Component {
   }
 
   /**
-   * Determines whether or not the current video is at the live edge based on the
-   * playhead state and duration.
+   * Determines whether or not the current video is at the end (VOD) or at the
+   * live edge (DVR Live Streams) based on the playhead state and duration.
    * @private
-   * @return {Boolean} True if the video is at the live edge, false otherwise.
-   * Note: This function always returns false for VOD.
+   * @return {Boolean} True if the video is at the video end/live edge, false otherwise.
    */
-  isAtLiveEdge() {
+  isAtVideoEnd() {
     const isLiveStream = Utils.getPropertyValue(
       this.props.controller,
       'state.isLiveStream',
       false
     );
+    let isVideoEnd = false;
+    const duration = Utils.getPropertyValue(this.props.controller, 'state.duration', 0);
+    const currentPlayhead = Utils.ensureNumber(this.props.currentPlayhead, 0);
+
     if (isLiveStream) {
-      const duration = Utils.getPropertyValue(this.props.controller, 'state.duration', 0);
-      const currentPlayhead = Utils.ensureNumber(this.props.currentPlayhead, 0);
-      const isLiveNow = Math.abs(currentPlayhead - duration) < 1;
-      return isLiveNow;
+      isVideoEnd = Math.abs(currentPlayhead - duration) < 1;
+    } else {
+      isVideoEnd = currentPlayhead >= duration;
     }
-    return false;
+    return isVideoEnd;
   }
 
   /**
@@ -197,7 +199,7 @@ class SkipControls extends React.Component {
         className="oo-center-button oo-skip-forward"
         icon="forward"
         ariaLabel={skipForwardAriaLabel}
-        disabled={this.isAtLiveEdge() || !duration}
+        disabled={this.isAtVideoEnd() || !duration}
         onClick={this.onSkipForward}>
         <span className="oo-btn-counter">{skipTimes.forward}</span>
       </HoldControlButton>

--- a/tests/components/higher-order/holdOnClick-test.js
+++ b/tests/components/higher-order/holdOnClick-test.js
@@ -87,4 +87,13 @@ describe('holdOnClick', function() {
     clickSpy.mockRestore();
   });
 
+  it('should release click when component is disabled', function() {
+    renderComponent();
+    const spy = jest.spyOn(wrapper.instance(), 'releaseClick');
+    expect(spy.mock.calls.length).toBe(0);
+    wrapper.setProps({ disabled: true });
+    expect(spy.mock.calls.length).toBe(1);
+    clickSpy.mockRestore();
+  });
+
 });

--- a/tests/components/skipControls-test.js
+++ b/tests/components/skipControls-test.js
@@ -187,17 +187,34 @@ describe('SkipControls', function() {
     props.controller.state.duration = 100;
     props.currentPlayhead = 100;
     renderComponent();
-    expect(component.isAtLiveEdge()).toBe(true);
-    props.controller.state.isLiveStream = false;
+    expect(component.isAtVideoEnd()).toBe(true);
+    props.controller.state.isLiveStream = true;
     props.controller.state.duration = 100;
-    props.currentPlayhead = 100;
+    props.currentPlayhead = 50;
     renderComponent();
-    expect(component.isAtLiveEdge()).toBe(false);
+    expect(component.isAtVideoEnd()).toBe(false);
     props.controller.state.isLiveStream = true;
     props.controller.state.duration = 100;
     props.currentPlayhead = 0;
     renderComponent();
-    expect(component.isAtLiveEdge()).toBe(false);
+    expect(component.isAtVideoEnd()).toBe(false);
+  });
+
+  it('should correctly determine whether video is at end', function() {
+    props.controller.state.isLiveStream = false;
+    props.controller.state.duration = 100;
+    props.currentPlayhead = 100;
+    renderComponent();
+    expect(component.isAtVideoEnd()).toBe(true);
+    props.currentPlayhead = 99;
+    renderComponent();
+    expect(component.isAtVideoEnd()).toBe(false);
+    props.currentPlayhead = 0;
+    renderComponent();
+    expect(component.isAtVideoEnd()).toBe(false);
+    props.currentPlayhead = 101;
+    renderComponent();
+    expect(component.isAtVideoEnd()).toBe(true);
   });
 
   it('should set inactive class when component is inactive', function() {

--- a/tests/components/skipControls-test.js
+++ b/tests/components/skipControls-test.js
@@ -187,17 +187,17 @@ describe('SkipControls', function() {
     props.controller.state.duration = 100;
     props.currentPlayhead = 100;
     renderComponent();
-    expect(component.isAtVideoEnd()).toBe(true);
+    expect(component.isAtVideoEdge()).toBe(true);
     props.controller.state.isLiveStream = true;
     props.controller.state.duration = 100;
     props.currentPlayhead = 50;
     renderComponent();
-    expect(component.isAtVideoEnd()).toBe(false);
+    expect(component.isAtVideoEdge()).toBe(false);
     props.controller.state.isLiveStream = true;
     props.controller.state.duration = 100;
     props.currentPlayhead = 0;
     renderComponent();
-    expect(component.isAtVideoEnd()).toBe(false);
+    expect(component.isAtVideoEdge()).toBe(false);
   });
 
   it('should correctly determine whether video is at end', function() {
@@ -205,16 +205,16 @@ describe('SkipControls', function() {
     props.controller.state.duration = 100;
     props.currentPlayhead = 100;
     renderComponent();
-    expect(component.isAtVideoEnd()).toBe(true);
+    expect(component.isAtVideoEdge()).toBe(true);
     props.currentPlayhead = 99;
     renderComponent();
-    expect(component.isAtVideoEnd()).toBe(false);
+    expect(component.isAtVideoEdge()).toBe(false);
     props.currentPlayhead = 0;
     renderComponent();
-    expect(component.isAtVideoEnd()).toBe(false);
+    expect(component.isAtVideoEdge()).toBe(false);
     props.currentPlayhead = 101;
     renderComponent();
-    expect(component.isAtVideoEnd()).toBe(true);
+    expect(component.isAtVideoEdge()).toBe(true);
   });
 
   it('should set inactive class when component is inactive', function() {


### PR DESCRIPTION
The "Skip Forward" button will basically be greyed out and disabled when the video has ended. This is mostly for the audio-only player, but the behavior should be consistent for all player types.

Note that this doesn't fully fix the issue from PLAYER-4582, this is just a partial update for now.