### PR TITLE
[PBW-7594] Fixing slider drag action on Firefox

### DIFF
--- a/js/components/slider.js
+++ b/js/components/slider.js
@@ -130,6 +130,10 @@ var Slider = createReactClass({
 
   onMouseUp: function(event) {
     Utils.blurOnMouseUp(event);
+
+    this.setState({
+      isDragging: false
+    });
   },
 
   onMouseMove: function(event) {

--- a/js/components/slider.js
+++ b/js/components/slider.js
@@ -7,6 +7,13 @@ var createReactClass = require('create-react-class');
 var PropTypes = require('prop-types');
 
 var Slider = createReactClass({
+
+  getInitialState: function() {
+    return {
+      isDragging: false
+    };
+  },
+
   componentDidMount: function() {
     this.handleSliderColoring(this.props);
 
@@ -116,19 +123,16 @@ var Slider = createReactClass({
   },
 
   onMouseDown: function() {
-    this.dragging = true;
+    this.setState({
+      isDragging: true
+    });
   },
 
   onMouseUp: function(event) {
-    this.dragging = false;
     Utils.blurOnMouseUp(event);
   },
 
   onMouseMove: function(event) {
-    // Avoid showing the keyboard focus outline when dragging the slider with the mouse
-    if (this.dragging) {
-      Utils.blurOnMouseUp(event);
-    }
     // IE11 doesn't update the value by itself when dragging the slider
     // with the mouse
     if (this.isIeFixRequired()) {
@@ -217,11 +221,15 @@ var Slider = createReactClass({
   render: function() {
     var aria = this.getAriaValues();
 
+    const className = ClassNames('oo-slider', this.props.className, {
+      'oo-dragging': this.state.isDragging
+    });
+
     return (
       <input
         type="range"
         ref={this.props.itemRef}
-        className={ClassNames('oo-slider', this.props.className)}
+        className={className}
         min={this.props.minValue}
         max={this.props.maxValue}
         value={this.props.value}

--- a/scss/components/_slider.scss
+++ b/scss/components/_slider.scss
@@ -51,6 +51,11 @@
   @include remove-highlight-tab();
 }
 
+[type=range].oo-slider.oo-dragging,
+[type=range].oo-slider.oo-dragging:focus {
+  @include remove-highlight-tab();
+}
+
 //moz
 .oo-slider[type=range]::-moz-range-track {
     width: #{$slider-width};

--- a/tests/components/slider-test.js
+++ b/tests/components/slider-test.js
@@ -161,7 +161,7 @@ describe('Slider', function() {
     component.simulate('mouseMove', { currentTarget: element });
     expect(element.classList.contains('oo-dragging')).toBe(true);
     component.simulate('mouseUp', { currentTarget: element });
-    expect(element.classList.contains('oo-dragging')).toBe(true);
+    expect(element.classList.contains('oo-dragging')).toBe(false);
   });
 
 });

--- a/tests/components/slider-test.js
+++ b/tests/components/slider-test.js
@@ -153,13 +153,15 @@ describe('Slider', function() {
     expect(element.getAttribute('value')).toBe('0.5');
   });
 
-  it('should blur focus on mousemove', function() {
-    var spy = sinon.spy(Utils, 'blurOnMouseUp');
+  it('should set oo-dragging class on mouse down and remove it on mouse up', function() {
     renderComponent();
+    expect(element.classList.contains('oo-dragging')).toBe(false);
     component.simulate('mouseDown', { currentTarget: element });
+    expect(element.classList.contains('oo-dragging')).toBe(true);
     component.simulate('mouseMove', { currentTarget: element });
-    expect(spy.callCount).toBe(1);
-    spy.restore();
+    expect(element.classList.contains('oo-dragging')).toBe(true);
+    component.simulate('mouseUp', { currentTarget: element });
+    expect(element.classList.contains('oo-dragging')).toBe(true);
   });
 
 });


### PR DESCRIPTION
This fixes an issue in which the CC menu slider couldn't be dragged with the mouse on Firefox. It also maintains the behavior in which the blue focus outline is not shown while interacting with the mouse, but is activated when using the keyboard.