### PR TITLE
[PLAYER-4369] Add in ui element to show that you are casting

### DIFF
--- a/js/components/castPanel.js
+++ b/js/components/castPanel.js
@@ -1,0 +1,39 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+const ClassNames = require('classnames');
+
+class CastPanel extends React.Component {
+
+    shouldComponentUpdate(nextProps) {
+        if (nextProps.connected !== this.props.connected) {
+            return true;
+        }
+        return false;
+    }
+
+    render() {
+        const castPanelClass = ClassNames({
+            'oo-info-panel-cast': true,
+            'oo-inactive': !this.props.connected
+          },
+          this.props.className);
+        
+        return (
+            <div className={castPanelClass}>
+                <p>Connected to <span>{this.props.device}</span></p>
+            </div>
+        )
+    }
+}
+
+CastPanel.propTypes = {
+    device: PropTypes.string,
+    connected: PropTypes.bool
+}
+
+CastPanel.defaultProps = {
+    device: "",
+    connected: false
+}
+
+module.exports = CastPanel;

--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -870,7 +870,7 @@ var ControlBar = createReactClass({
         continue;
       }
 
-      if (defaultItems[k].name === 'chromecast' && !this.props.controller.state.enableChromecast) {
+      if (defaultItems[k].name === 'chromecast' && !this.props.controller.state.cast.showButton) {
         continue;
       }
       

--- a/js/components/icon.js
+++ b/js/components/icon.js
@@ -7,7 +7,7 @@ var PropTypes = require('prop-types');
 var Icon = createReactClass({
   shouldComponentUpdate: function(nextProps) {
     var updateComponent = false;
-    if (this.props && (this.props.icon !== nextProps.icon || this.props.className !== nextProps.className)) {
+    if (this.props && (this.props.icon !== nextProps.icon || this.props.className !== nextProps.className || this.props.style !== nextProps.style)) {
       updateComponent = true;
     }
     return updateComponent;

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -29,7 +29,8 @@ var CONSTANTS = {
     VIDEO_QUALITY_SCREEN: 'videoQualityScreen',
     ERROR_SCREEN: 'errorScreen',
     MULTI_AUDIO_SCREEN: 'multiAudioScreen',
-    PLAYBACK_SPEED_SCREEN: 'playbackSpeedScreen'
+    PLAYBACK_SPEED_SCREEN: 'playbackSpeedScreen',
+    CAST_SCREEN: 'castScreen'
   },
 
   MENU_OPTIONS: {

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -29,8 +29,7 @@ var CONSTANTS = {
     VIDEO_QUALITY_SCREEN: 'videoQualityScreen',
     ERROR_SCREEN: 'errorScreen',
     MULTI_AUDIO_SCREEN: 'multiAudioScreen',
-    PLAYBACK_SPEED_SCREEN: 'playbackSpeedScreen',
-    CAST_SCREEN: 'castScreen'
+    PLAYBACK_SPEED_SCREEN: 'playbackSpeedScreen'
   },
 
   MENU_OPTIONS: {

--- a/js/views/endScreen.js
+++ b/js/views/endScreen.js
@@ -12,6 +12,8 @@ var React = require('react'),
     Utils = require('../components/utils');
 var createReactClass = require('create-react-class');
 
+const CastPanel = require('../components/castPanel');
+
 var EndScreen = createReactClass({
   mixins: [ResizeMixin],
 
@@ -51,10 +53,7 @@ var EndScreen = createReactClass({
     };
 
     if (this.props.controller.state.cast.connected) {
-      actionIconStyle = Utils.extend(
-        {fontSize: '125px'},
-        actionIconStyle
-      );
+      actionIconStyle['fontSize'] = '125px';
     }
 
     var titleStyle = {
@@ -94,8 +93,6 @@ var EndScreen = createReactClass({
 
     // Shows the information of the chromecast device just below the replay icon
     const castPanelClass = ClassNames({
-      'oo-info-panel-cast': true,
-      'oo-inactive': !this.props.controller.state.cast.connected,
       'oo-info-panel-cast-bottom': true
     })
 
@@ -134,9 +131,11 @@ var EndScreen = createReactClass({
           <Icon {...this.props} icon="replay" style={actionIconStyle} />
         </button>
 
-        <div className={castPanelClass}>
-          <p>Connected to <span>{this.props.controller.state.cast.device}</span></p>
-        </div>
+        <CastPanel
+          device={this.props.controller.state.cast.device}
+          connected={this.props.controller.state.cast.connected}
+          className={castPanelClass}
+        />
 
         <div className="oo-interactive-container">
           <ControlBar

--- a/js/views/endScreen.js
+++ b/js/views/endScreen.js
@@ -50,6 +50,13 @@ var EndScreen = createReactClass({
       opacity: this.props.skinConfig.endScreen.replayIconStyle.opacity
     };
 
+    if (this.props.controller.state.cast.connected) {
+      actionIconStyle = Utils.extend(
+        {fontSize: '125px'},
+        actionIconStyle
+      );
+    }
+
     var titleStyle = {
       color: this.props.skinConfig.startScreen.titleFont.color
     };
@@ -85,6 +92,13 @@ var EndScreen = createReactClass({
       });
     }
 
+    // Shows the information of the chromecast device just below the replay icon
+    const castPanelClass = ClassNames({
+      'oo-info-panel-cast': true,
+      'oo-inactive': !this.props.controller.state.cast.connected,
+      'oo-info-panel-cast-bottom': true
+    })
+
     var titleMetadata = (
       <div className={titleClass} style={titleStyle}>
         {this.props.contentTree.title}
@@ -119,6 +133,10 @@ var EndScreen = createReactClass({
         >
           <Icon {...this.props} icon="replay" style={actionIconStyle} />
         </button>
+
+        <div className={castPanelClass}>
+          <p>Connected to <span>{this.props.controller.state.cast.device}</span></p>
+        </div>
 
         <div className="oo-interactive-container">
           <ControlBar

--- a/js/views/higher-order/withAutoHide.js
+++ b/js/views/higher-order/withAutoHide.js
@@ -55,6 +55,11 @@ const withAutoHide = function(ComposedComponent) {
           this.props.controller.showControlBar();
           this.startHideControlBarTimer();
         }
+
+        if (nextProps.controller.state.cast.connected) {
+          this.props.controller.showControlBar();
+          this.cancelHideControlBarTimer();
+        }
       }
     }
 

--- a/js/views/pauseScreen.js
+++ b/js/views/pauseScreen.js
@@ -15,6 +15,7 @@ const Utils = require('../components/utils');
 const CONSTANTS = require('./../constants/constants');
 const ViewControlsVr = require('../components/viewControlsVr');
 const withAutoHide = require('./higher-order/withAutoHide.js');
+const CastPanel = require('../components/castPanel');
 
 
 /**
@@ -293,8 +294,6 @@ class PauseScreen extends React.Component {
     // Depends of there's another element/panel at the center of the player we will push down
     // the cast panel to allow both elements be visible to the user
     const castPanelClass = ClassNames({
-      'oo-info-panel-cast': true,
-      'oo-inactive': !this.props.controller.state.cast.connected,
       'oo-info-panel-cast-bottom': skipControlsEnabled
     })
 
@@ -333,9 +332,11 @@ class PauseScreen extends React.Component {
           <Icon {...this.props} icon="pause" style={actionIconStyle} />
         </button>
 
-        <div className={castPanelClass}>
-          <p>Connected to <span>{this.props.controller.state.cast.device}</span></p>
-        </div>
+        <CastPanel
+          device={this.props.controller.state.cast.device}
+          connected={this.props.controller.state.cast.connected}
+          className={castPanelClass}
+        />
 
         {viewControlsVr}
 

--- a/js/views/pauseScreen.js
+++ b/js/views/pauseScreen.js
@@ -180,7 +180,8 @@ class PauseScreen extends React.Component {
         this.props.controller.state.controlBarVisible,
       'oo-animate-fade':
         this.state.animate &&
-        !this.props.pauseAnimationDisabled &&
+        (!this.props.pauseAnimationDisabled ||
+          this.props.controller.state.cast.connected) &&
         this.props.controller.state.controlBarVisible
     });
     const infoPanelClass = ClassNames({
@@ -274,8 +275,34 @@ class PauseScreen extends React.Component {
       this.props.controller.removeBlur();
     }
 
+    // Always show the poster image on cast session
+    const posterImageUrl = this.props.skinConfig.startScreen.showPromo
+      ? this.props.contentTree.promo_image
+      : '';
+    const posterStyle = {};
+    if (Utils.isValidString(posterImageUrl)) {
+      posterStyle.backgroundImage = 'url(\'' + posterImageUrl + '\')';
+    }
+
+    const stateScreenPosterClass = ClassNames({
+      'oo-blur': true,
+      'oo-state-screen-poster': this.props.skinConfig.startScreen.promoImageSize !== 'small',
+      'oo-state-screen-poster-small': this.props.skinConfig.startScreen.promoImageSize === 'small'
+    });
+
+    // Depends of there's another element/panel at the center of the player we will push down
+    // the cast panel to allow both elements be visible to the user
+    const castPanelClass = ClassNames({
+      'oo-info-panel-cast': true,
+      'oo-inactive': !this.props.controller.state.cast.connected,
+      'oo-info-panel-cast-bottom': skipControlsEnabled
+    })
+
+
     return (
       <div className="oo-state-screen oo-pause-screen">
+        {this.props.controller.state.cast.connected && <div className={stateScreenPosterClass} style={posterStyle}></div>}
+
         {!this.props.controller.videoVr && this.state.containsText && <div className={fadeUnderlayClass} />}
 
         <div
@@ -305,6 +332,10 @@ class PauseScreen extends React.Component {
           tabIndex="-1">
           <Icon {...this.props} icon="pause" style={actionIconStyle} />
         </button>
+
+        <div className={castPanelClass}>
+          <p>Connected to <span>{this.props.controller.state.cast.device}</span></p>
+        </div>
 
         {viewControlsVr}
 

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -365,12 +365,52 @@ class PlayingScreen extends React.Component {
       'oo-controls-active': skipControlsEnabled && this.props.controller.state.controlBarVisible
     });
 
+    // Always show the poster image on cast session
+    const posterImageUrl = this.props.skinConfig.startScreen.showPromo
+      ? this.props.contentTree.promo_image
+      : '';
+    const posterStyle = {};
+    if (Utils.isValidString(posterImageUrl)) {
+      posterStyle.backgroundImage = 'url(\'' + posterImageUrl + '\')';
+    }
+
+    const stateScreenPosterClass = ClassNames({
+      'oo-blur': true,
+      'oo-state-screen-poster': this.props.skinConfig.startScreen.promoImageSize !== 'small',
+      'oo-state-screen-poster-small': this.props.skinConfig.startScreen.promoImageSize === 'small'
+    });
+
+    // Depends of there's another element/panel at the center of the player we will push down
+    // the cast panel to allow both elements be visible to the user
+    const castPanelClass = ClassNames({
+      'oo-info-panel-cast': true,
+      'oo-inactive': !this.props.controller.state.cast.connected,
+      'oo-info-panel-cast-bottom': skipControlsEnabled
+    })
+
+    // Add a blur only when the content it being casted on a chromecast device and a fading layer
+    if (this.props.controller.state.cast.connected) {
+      this.props.controller.addBlur();
+    } else {
+      this.props.controller.removeBlur();
+    }
+
+    const fadeUnderlayClass = ClassNames({
+      'oo-fading-underlay': true,
+      'oo-fading-underlay-active': this.props.controller.state.cast.connected,
+      'oo-animate-fade': true
+    });
+
     return (
       <div
         className={className}
         onTouchStart={this.handleTouchStart}
         onMouseOver={this.handleMouseOver}
       >
+        {this.props.controller.state.cast.connected && <div className={stateScreenPosterClass} style={posterStyle}></div>}
+
+        {this.props.controller.state.cast.connected && <div className={fadeUnderlayClass} />}
+
         <div
           className={CONSTANTS.CLASS_NAMES.SELECTABLE_SCREEN}
           onMouseDown={this.handlePlayerMouseDown}
@@ -385,6 +425,10 @@ class PlayingScreen extends React.Component {
         {vrIcon}
 
         <Watermark {...this.props} controlBarVisible={this.props.controller.state.controlBarVisible} />
+
+        <div className={castPanelClass}>
+          <p>Connected to <span>{this.props.controller.state.cast.device}</span></p>
+        </div>
 
         {this.props.controller.state.buffering ? (
           <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url} />

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -16,6 +16,7 @@ const Icon = require('../components/icon');
 const SkipControls = require('../components/skipControls');
 const UnmuteIcon = require('../components/unmuteIcon');
 const withAutoHide = require('./higher-order/withAutoHide.js');
+const CastPanel = require('../components/castPanel');
 
 /**
  * Represents a screen when a video is played
@@ -383,8 +384,6 @@ class PlayingScreen extends React.Component {
     // Depends of there's another element/panel at the center of the player we will push down
     // the cast panel to allow both elements be visible to the user
     const castPanelClass = ClassNames({
-      'oo-info-panel-cast': true,
-      'oo-inactive': !this.props.controller.state.cast.connected,
       'oo-info-panel-cast-bottom': skipControlsEnabled
     })
 
@@ -425,10 +424,12 @@ class PlayingScreen extends React.Component {
         {vrIcon}
 
         <Watermark {...this.props} controlBarVisible={this.props.controller.state.controlBarVisible} />
-
-        <div className={castPanelClass}>
-          <p>Connected to <span>{this.props.controller.state.cast.device}</span></p>
-        </div>
+        
+        <CastPanel
+          device={this.props.controller.state.cast.device}
+          connected={this.props.controller.state.cast.connected}
+          className={castPanelClass}
+        />
 
         {this.props.controller.state.buffering ? (
           <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url} />

--- a/scss/base/_variables.scss
+++ b/scss/base/_variables.scss
@@ -70,13 +70,13 @@ $font-size-root:               16px !default;
 $font-size-base:               1em !default;
 //$font-size-lg:               1.25em !default;
 $font-size-lg-screen-title:    1.9em !default;
-$font-size-lg-screen-desc:     1.3em !default;
+$font-size-lg-screen-desc:     1.8em !default;
 $font-size-md-screen-title:    1.6em !default;
 $font-size-md-screen-desc:     1.1em !default;
 $font-size-sm-screen-title:    1.1em !default;
 $font-size-sm-screen-desc:     0.8em !default;
 //$font-size-sm:               .85em !default;
-//$font-size-xs:               .75em !default;
+$font-size-xs:                 0.6em !default;
 //
 $line-height:                1.5 !default;
 //

--- a/scss/components/_state-screen.scss
+++ b/scss/components/_state-screen.scss
@@ -135,6 +135,36 @@
     left:-3%;
   }
 
+  .oo-info-panel-cast {
+    @extend .oo-center-vertical-horizontal;
+    @include vendor-prefixes (transition, $fade-up-transition);
+    text-align: center;
+    max-width: 80%;
+    border: 1px solid gray;
+    border-radius: 3px;
+    width: 100%;
+
+    &.oo-inactive {
+      opacity: 0;
+      transform: translate(-50%, -90%);
+    }
+
+    &.oo-info-panel-cast-bottom {
+      top: 70%;
+    }
+
+    p {
+      font-family: $font-family-roboto-condensed; //this.props.skinConfig.startScreen.titleFont.fontFamily
+      font-size: $font-size-md-screen-desc; //this.props.skinConfig.startScreen.descriptionFont.fontSize
+      padding: 2%;
+      margin: 0;
+
+      span {
+        font-weight: bold;
+      }
+    }
+  }
+
   button.oo-action-icon {
     margin: 0;
     padding: 0;

--- a/scss/responsive/_large.scss
+++ b/scss/responsive/_large.scss
@@ -21,12 +21,12 @@
         font-size: 3.0em;
       }
       .oo-state-screen-description {
-        font-size: 1.8em;
+        font-size: $font-size-lg-screen-desc;
       }
     }
     .oo-info-panel-cast {
       p {
-        font-size: 1.8em;
+        font-size: $font-size-lg-screen-desc;
       }
     }
   }

--- a/scss/responsive/_large.scss
+++ b/scss/responsive/_large.scss
@@ -24,6 +24,11 @@
         font-size: 1.8em;
       }
     }
+    .oo-info-panel-cast {
+      p {
+        font-size: 1.8em;
+      }
+    }
   }
 
   // Discovery Panel

--- a/scss/responsive/_xsmall.scss
+++ b/scss/responsive/_xsmall.scss
@@ -34,12 +34,12 @@
         font-size: 1em;
       }
       .oo-state-screen-description {
-        font-size: 0.6em;
+        font-size: $font-size-xs;
       }
     }
     .oo-info-panel-cast {
       p {
-        font-size: 0.6em;
+        font-size: $font-size-xs;
       }
     }
   }

--- a/scss/responsive/_xsmall.scss
+++ b/scss/responsive/_xsmall.scss
@@ -37,6 +37,11 @@
         font-size: 0.6em;
       }
     }
+    .oo-info-panel-cast {
+      p {
+        font-size: 0.6em;
+      }
+    }
   }
 
   // Discovery Panel

--- a/tests/components/castPanel-test.js
+++ b/tests/components/castPanel-test.js
@@ -1,0 +1,44 @@
+jest
+.dontMock('../../js/components/castPanel')
+.dontMock('classnames');
+
+var React = require('react');
+var Enzyme = require('enzyme');
+var CastPanel = require('../../js/components/castPanel');
+
+describe('CastPanel', function(){
+    
+    function renderComponent(className) {
+        return Enzyme.mount(
+            <CastPanel 
+                device="Test Panel"
+                connected={false}
+                className={className}
+            />
+        );
+    };
+
+    it('Should render a cast panel', function(){
+        const panel = renderComponent();
+        expect(panel).toBeTruthy();
+    });
+
+    it('Should render a hidden cast panel', function(){
+        const panel = renderComponent();
+        expect(panel.getDOMNode().classList.contains('oo-inactive')).toBe(true);
+    });
+
+    it('Should render and show a cast panel', function(){
+        const panel = renderComponent();
+        expect(panel.getDOMNode().classList.contains('oo-inactive')).toBe(true);
+        panel.setProps({connected:true});
+        expect(panel.getDOMNode().classList.contains('oo-inactive')).toBe(false);
+        expect(panel.find('p span').text()).toBe('Test Panel');
+    });
+
+    it('Should render a cast panel with a given className', function(){
+        const panel = renderComponent('my-class-test');
+        expect(panel.getDOMNode().classList.contains('my-class-test')).toBe(true);
+    });
+});
+

--- a/tests/components/controlBar-test.js
+++ b/tests/components/controlBar-test.js
@@ -78,6 +78,11 @@ describe('ControlBar', function() {
         skipControls: {
           hasPreviousVideos: false,
           hasNextVideos: false
+        },
+        cast: {
+          showButton: false,
+          connected: false,
+          device: ""
         }
       },
       cancelTimer: function() {},
@@ -1299,7 +1304,7 @@ describe('ControlBar', function() {
     });
 
     it('Should not show chromecast button when player param not exist', () => {
-      baseMockController.state.enableChromecast = true;
+      baseMockController.state.cast.showButton = true;
       var wrapper = Enzyme.mount(getControlBar());
       var chromecastBtn = wrapper.find(".oo-cast");
       expect(chromecastBtn.length).toBe(1);

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -1594,7 +1594,7 @@ describe('Controller', function() {
           appId: "45APPID"
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(true);
+      expect(controller.state.cast.showButton).toBe(true);
     });
 
     it('Should disable the chromecast button at state when appId is not an string and enable it is true', () => {
@@ -1604,7 +1604,7 @@ describe('Controller', function() {
           appId: 45
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
     it('Should disable the chromecast button at state when appId is empty and enable it is true', () => {
@@ -1614,7 +1614,7 @@ describe('Controller', function() {
           appId: ""
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
     it('Should disable the chromecast button at state when appId is null and enable it is true', () => {
@@ -1624,7 +1624,7 @@ describe('Controller', function() {
           appId: null
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
     it('Should disable the chromecast button at state when appId is not provided and enable it is true', () => {
@@ -1633,7 +1633,7 @@ describe('Controller', function() {
           enable: true
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
     it('Should disable the chromecast button at state when appId is valid and enable it is false', () => {
@@ -1643,7 +1643,7 @@ describe('Controller', function() {
           appId: "45APPID"
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
     it('Should disable the chromecast button at state when appId is valid and enable it is null', () => {
@@ -1653,7 +1653,7 @@ describe('Controller', function() {
           appId: "45APPID"
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
     it('Should disable the chromecast button at state when appId is valid and there is no enable property', () => {
@@ -1662,7 +1662,7 @@ describe('Controller', function() {
           appId: "45APPID"
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
     it('Should disable the chromecast button at state when appId is valid and enable it is false', () => {
@@ -1672,7 +1672,7 @@ describe('Controller', function() {
           appId: "45APPID"
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
     it('Should disable the chromecast button at state when appId is null and enable it is false', () => {
@@ -1682,12 +1682,12 @@ describe('Controller', function() {
           appId: null
         }
       }, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
     it('Should disable the chromecast button at state when chromecaste param is not present', () => {
       controller.loadConfigData({}, {}, {}, {});
-      expect(controller.state.enableChromecast).toBe(false);
+      expect(controller.state.cast.showButton).toBe(false);
     });
 
   });

--- a/tests/skin-test.js
+++ b/tests/skin-test.js
@@ -63,6 +63,11 @@ var skinControllerMock = {
     skipControls: {
       hasPreviousVideos: false,
       hasNextVideos: false
+    },
+    cast: {
+      showButton: false,
+      connected: false,
+      device: ""
     }
   },
   addBlur: function() {},

--- a/tests/views/endScreen-test.js
+++ b/tests/views/endScreen-test.js
@@ -15,6 +15,8 @@ var skinConfig = require('../../config/skin.json');
 var Utils = require('../../js/components/utils');
 var CONSTANTS = require('../../js/constants/constants');
 
+const CastPanel = require('../../js/components/castPanel');
+
 describe('EndScreen', function() {
   var mockController, mockSkinConfig, mockContentTree;
 
@@ -36,7 +38,7 @@ describe('EndScreen', function() {
         volumeState: {
           muted: false,
           volume: 1,
-          volumeStateVisible: true, 
+          volumeStateVisible: true,
           volumeSliderVisible: true
         },
         closedCaptionOptions: {},
@@ -47,6 +49,11 @@ describe('EndScreen', function() {
         },
         scrubberBar: {
           isHovering: false
+        },
+        cast: {
+          showButton: false,
+          connected: false,
+          device: ""
         }
       },
       cancelTimer: function() {},
@@ -57,7 +64,7 @@ describe('EndScreen', function() {
       setVolume: function() {}
     };
     mockSkinConfig = Utils.clone(skinConfig);
-    mockContentTree = {'description': 'description', 'title': 'title'};
+    mockContentTree = {'description': 'description', 'title': 'title', promo_image: 'image.png'};
   });
 
   it('creates an EndScreen with replay button', function() {
@@ -124,5 +131,24 @@ describe('EndScreen', function() {
     // description and title are hidden
     var title = wrapper.find('.oo-state-screen-title');
     expect(title.getDOMNode().className).toMatch('hidden');
+  });
+
+  it('[Chromecast] should not display cast panel', function(){
+    const wrapper = Enzyme.mount(getEndScreen());
+    const castPanel = wrapper.find(CastPanel);
+    expect(castPanel.props().connected).toBe(false);
+  });
+
+  it('[Chromecast] should display the cast panel located near to the bottom', function(){
+    mockController.state.cast = {
+      connected: true,
+      device: "PlayerTV"
+    }
+    mockSkinConfig.skipControls.enabled = true;
+    const wrapper = Enzyme.mount(getEndScreen());
+    const castPanel = wrapper.find(CastPanel);
+    expect(castPanel.props().connected).toBe(true);
+    expect(castPanel.props().device).toBe("PlayerTV");
+    expect(wrapper.find('.oo-info-panel-cast.oo-info-panel-cast-bottom').length).toBe(1);
   });
 });

--- a/tests/views/higher-order/withAutoHide-test.js
+++ b/tests/views/higher-order/withAutoHide-test.js
@@ -71,6 +71,11 @@ describe('withAutoHide', function() {
         multiAudioOptions: {},
         videoQualityOptions: {
           availableBitrates: null
+        },
+        cast: {
+          showButton: false,
+          connected: false,
+          device: ""
         }
       },
       cancelTimer: function() {},
@@ -197,6 +202,22 @@ describe('withAutoHide', function() {
 
     wrapper.simulate('keyDown', {key: 'Dead', which: 16, keyCode: 16});
     expect(autoHide && controlBar).toBe(false);
+  });
+
+  it('Should deactivate the autohide when a cast session is started', function(){
+    var controlBar = false;
+
+    mockController.showControlBar = function() {
+      controlBar = true;
+    };
+
+    const wrapper = renderAutoHideScreen(false);
+    expect(controlBar).toBe(false);
+
+    mockController.state.cast.connected = true;
+    wrapper.setProps({controller: mockController});
+
+    expect(controlBar).toBe(true);
   });
 
 });

--- a/tests/views/pauseScreen-test.js
+++ b/tests/views/pauseScreen-test.js
@@ -15,6 +15,8 @@ var SkipControls = require('../../js/components/skipControls');
 var Utils = require('../../js/components/utils');
 var CONSTANTS = require('../../js/constants/constants');
 
+const CastPanel = require('../../js/components/castPanel');
+
 import {PauseScreen} from '../../js/views/pauseScreen';
 
 describe('PauseScreen', function() {
@@ -68,6 +70,11 @@ describe('PauseScreen', function() {
         playbackSpeedOptions: { currentSpeed: 1 },
         videoQualityOptions: {
           availableBitrates: null
+        },
+        cast: {
+          showButton: false,
+          connected: false,
+          device: ""
         }
       },
       addBlur: function() {},
@@ -83,6 +90,8 @@ describe('PauseScreen', function() {
       togglePlayPause: () => {}
     };
     mockContentTree = {
+      promo_image: 'image.png',
+      description: 'description',
       title: 'title'
     };
     mockSkinConfig = Utils.clone(skinConfig);
@@ -199,6 +208,68 @@ describe('PauseScreen', function() {
     mockSkinConfig.skipControls.enabled = true;
     wrapper = Enzyme.mount(component);
     expect(wrapper.find(SkipControls).length).toBe(1);
+  });
+
+  it('[Chromecast] should not display cast panel', function(){
+    mockSkinConfig.skipControls.enabled = false;
+    const wrapper = Enzyme.mount(getPauseScreen());
+    const castPanel = wrapper.find(CastPanel);
+    expect(castPanel.props().connected).toBe(false);
+  });
+
+  it('[Chromecast] should display cast panel with poster image and blur effect', function(){
+    let wrapper;
+    const component = (
+      <PauseScreen
+        responsiveView="md"
+        skinConfig={mockSkinConfig}
+        controller={mockController}
+        contentTree={mockContentTree}
+        handleVrPlayerClick={() => {}}
+        closedCaptionOptions={{ cueText: 'sample text' }}
+        currentPlayhead={0}
+        playerState={CONSTANTS.STATE.PAUSE}
+        totalTime={"60:00"}
+        playheadTime={"00:00"}
+      />
+    );
+    mockController.state.cast = {
+      connected: true,
+      device: "PlayerTV"
+    }
+    wrapper = Enzyme.mount(component);
+    const castPanel = wrapper.find(CastPanel);
+    expect(castPanel.props().connected).toBe(true);
+    expect(castPanel.props().device).toBe("PlayerTV");
+    expect(wrapper.find('.oo-state-screen-poster.oo-blur').length).toBe(1);
+  });
+
+  it('[Chromecast] should display cast panel with poster image, blur effect and located near to the bottom', function(){
+    const component = (
+      <PauseScreen
+        responsiveView="md"
+        skinConfig={mockSkinConfig}
+        controller={mockController}
+        contentTree={mockContentTree}
+        handleVrPlayerClick={() => {}}
+        closedCaptionOptions={{ cueText: 'sample text' }}
+        currentPlayhead={0}
+        playerState={CONSTANTS.STATE.PAUSE}
+        totalTime={"60:00"}
+        playheadTime={"00:00"}
+      />
+    );
+    mockController.state.cast = {
+      connected: true,
+      device: "PlayerTV"
+    }
+    mockSkinConfig.skipControls.enabled = true;
+    const wrapper = Enzyme.mount(component);
+    const castPanel = wrapper.find(CastPanel);
+    expect(castPanel.props().connected).toBe(true);
+    expect(castPanel.props().device).toBe("PlayerTV");
+    expect(wrapper.find('.oo-info-panel-cast.oo-info-panel-cast-bottom').length).toBe(1);
+    expect(wrapper.find('.oo-state-screen-poster.oo-blur').length).toBe(1);
   });
 
 });

--- a/tests/views/playingScreen-test.js
+++ b/tests/views/playingScreen-test.js
@@ -15,6 +15,8 @@ var TextTrackPanel = require('../../js/components/textTrackPanel');
 var Utils = require('../../js/components/utils');
 var CONSTANTS = require('../../js/constants/constants');
 
+const CastPanel = require('../../js/components/castPanel');
+
 import {PlayingScreen} from '../../js/views/playingScreen';
 const ControlBar = require('../../js/components/controlBar');
 
@@ -34,6 +36,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
         cancelHideControlBarTimer={() => {
           if (mockController) {
             mockController.cancelTimer();
@@ -62,7 +65,7 @@ describe('PlayingScreen', function() {
           volume: 1,
           muted: false,
           mutingForAutoplay: false,
-          volumeStateVisible: true, 
+          volumeStateVisible: true,
           volumeSliderVisible: true
         },
         skipControls: {
@@ -80,6 +83,16 @@ describe('PlayingScreen', function() {
         playbackSpeedOptions: { currentSpeed: 1 },
         videoQualityOptions: {
           availableBitrates: null
+        },
+        cast: {
+          showButton: false,
+          connected: false,
+          device: ""
+        },
+        contentTree: {
+          promo_image: 'image.png',
+          description: 'description',
+          title: 'title'
         }
       },
       cancelTimer: function() {},
@@ -91,7 +104,9 @@ describe('PlayingScreen', function() {
       requestNextVideo: function() {},
       showControlBar: function() {},
       setVolume: function() {},
-      togglePlayPause: () => {}
+      togglePlayPause: () => {},
+      addBlur: () => {},
+      removeBlur: () => {}
     };
     mockSkinConfig = Utils.clone(skinConfig);
     closedCaptionOptions = {
@@ -127,6 +142,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />
     );
 
@@ -170,6 +186,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />
     );
     wrapper.instance().setState({
@@ -217,6 +234,7 @@ describe('PlayingScreen', function() {
             playerState={CONSTANTS.STATE.PLAYING}
             totalTime={"60:00"}
             playheadTime={"00:00"}
+            contentTree={mockController.state.contentTree}
         />);
 
     var screen = wrapper.find('.oo-state-screen-selectable');
@@ -261,6 +279,7 @@ describe('PlayingScreen', function() {
             playerState={CONSTANTS.STATE.PLAYING}
             totalTime={"60:00"}
             playheadTime={"00:00"}
+            contentTree={mockController.state.contentTree}
         />);
 
     var screen = wrapper.find('.oo-state-screen-selectable');
@@ -296,6 +315,7 @@ describe('PlayingScreen', function() {
         totalTime={"60:00"}
         playheadTime={"00:00"}
         startHideControlBarTimer={() => {}}
+        contentTree={mockController.state.contentTree}
       />);
 
     var screen1 = wrapper.find('.oo-interactive-container');
@@ -326,6 +346,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />
     );
 
@@ -374,6 +395,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />
     );
     const screen = wrapper.find('.oo-state-screen-selectable');
@@ -413,6 +435,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />
     );
     var screen = wrapper.find('.oo-state-screen-selectable');
@@ -440,6 +463,7 @@ describe('PlayingScreen', function() {
         closedCaptionOptions={closedCaptionOptions}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />, node
     );
 
@@ -454,6 +478,7 @@ describe('PlayingScreen', function() {
         closedCaptionOptions={closedCaptionOptions}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />, node
     );
 
@@ -473,6 +498,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />);
     var unmuteIcon = wrapper.find(UnmuteIcon);
     expect(unmuteIcon).toBeTruthy();
@@ -491,6 +517,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />);
     var unmuteIcons = wrapper.find(UnmuteIcon);
     expect(unmuteIcons.length).toBe(0);
@@ -509,6 +536,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />
     );
     expect(wrapper.props().controller.state.controlBarVisible).toBe(true);
@@ -523,6 +551,7 @@ describe('PlayingScreen', function() {
         playerState={CONSTANTS.STATE.PLAYING}
         totalTime={"60:00"}
         playheadTime={"00:00"}
+        contentTree={mockController.state.contentTree}
       />
     );
     expect(wrapper.props().controller.state.controlBarVisible).toBe(false);
@@ -597,6 +626,38 @@ describe('PlayingScreen', function() {
     });
     expect(spy.mock.calls.length).toBe(1);
     spy.mockRestore();
+  });
+
+  it('[Chromecast] should not display cast panel', function(){
+    const wrapper = renderPlayingScreen();
+    const castPanel = wrapper.find(CastPanel);
+    expect(castPanel.props().connected).toBe(false);
+  });
+
+  it('[Chromecast] should display cast panel with poster image and blur effect', function(){
+    mockController.state.cast = {
+      connected: true,
+      device: "PlayerTV"
+    }
+    const wrapper = renderPlayingScreen();
+    const castPanel = wrapper.find(CastPanel);
+    expect(castPanel.props().connected).toBe(true);
+    expect(castPanel.props().device).toBe("PlayerTV");
+    expect(wrapper.find('.oo-state-screen-poster.oo-blur').length).toBe(1);
+  });
+
+  it('[Chromecast] should display cast panel with poster image, blur effect and located near to the bottom', function(){
+    mockController.state.cast = {
+      connected: true,
+      device: "PlayerTV"
+    }
+    mockSkinConfig.skipControls.enabled = true;
+    const wrapper = renderPlayingScreen();
+    const castPanel = wrapper.find(CastPanel);
+    expect(castPanel.props().connected).toBe(true);
+    expect(castPanel.props().device).toBe("PlayerTV");
+    expect(wrapper.find('.oo-info-panel-cast.oo-info-panel-cast-bottom').length).toBe(1);
+    expect(wrapper.find('.oo-state-screen-poster.oo-blur').length).toBe(1);
   });
 
 });


### PR DESCRIPTION
This branch contains the needed modifications to show a panel information about the device used to cast the content through Chromecast.
These are the modified screens and his behaviour:

- **PlayingScreen**: It will show a panel in the middle of the screen with the device name. Right now has a little consideration for when the `skipControls` are enabled and it will be placed below this controls.

- **PauseScreen**: As the above screen, a panel will be shown in the center of the screen and it could react to be placed below of the `skipControls`, if active.

- **EndScreen**: At the end of the video, the size of the replay button will be a little bit smaller just to make room to place the device information just below of it.

As a general rule for all the screens, whether or not the controlBar were active by skin configurations once the player enter in the cast mode the controlBar will be showed and remains in that state until the cast session ends and it will get it's normal behaviour.

Once the cast session is started, the poster image will be used as a background. This is because if the user reload the page the auto-join policy will act and the player will get in sync with the Chromecast, but since there is no video loaded a black screen it's showed, so in order handle this in a graceful way I take the decision to use the poster image always to keep a linear state. 

