### PR TITLE
[PBW-7601] Preventing unmute button click from triggering ad clickthrough

### DIFF
--- a/js/components/unmuteIcon.js
+++ b/js/components/unmuteIcon.js
@@ -13,11 +13,14 @@ var UnmuteIcon = createReactClass({
   },
 
   unmuteClick: function(event) {
+    // Clicking on this button shouldn't trigger clicks on parent components
     event.stopPropagation();
     this.props.controller.handleMuteClick();
   },
 
   onMouseUp: function(event) {
+    // The AdScreen currently uses the mouseup event to handle ad clickthroughs,
+    // otherwise stopping propagation on the click event should've been enough
     event.stopPropagation();
   },
 

--- a/js/components/unmuteIcon.js
+++ b/js/components/unmuteIcon.js
@@ -13,7 +13,12 @@ var UnmuteIcon = createReactClass({
   },
 
   unmuteClick: function(event) {
+    event.stopPropagation();
     this.props.controller.handleMuteClick();
+  },
+
+  onMouseUp: function(event) {
+    event.stopPropagation();
   },
 
   componentDidMount: function() {
@@ -55,6 +60,7 @@ var UnmuteIcon = createReactClass({
       <button
         className={myClass}
         onClick={this.unmuteClick}
+        onMouseUp={this.onMouseUp}
         type="button"
         tabIndex="0"
         aria-label={volumeAriaLabel}

--- a/tests/components/unmuteIcon-test.js
+++ b/tests/components/unmuteIcon-test.js
@@ -15,6 +15,7 @@ describe('UnmuteIcon', function() {
 
   beforeEach(function() {
     mockController = {
+      handleMuteClick: () => {},
       state: {
         volumeState: {
           muted: true,
@@ -35,6 +36,30 @@ describe('UnmuteIcon', function() {
     var expanded = wrapper.find('.oo-expanded');
     var unmuteIcon = wrapper.find('.oo-unmute');
     expect(expanded).toEqual(unmuteIcon);
+  });
+
+  it('should not bubble click events up to parent', function() {
+    let parentClickCount = 0;
+    const spy = sinon.spy(mockController, 'handleMuteClick');
+    const onParentClick =  () => parentClickCount++;
+
+    const wrapper = Enzyme.mount(
+      <div
+        id="parent"
+        onClick={onParentClick}
+        onMouseUp={onParentClick}>
+        <UnmuteIcon
+          controller={mockController}
+          skinConfig={skinConfig} />
+      </div>
+    );
+    const button = wrapper.find('.oo-unmute');
+
+    button.simulate('click');
+    button.simulate('mouseup');
+    expect(parentClickCount).toBe(0);
+    expect(spy.callCount).toBe(1);
+    spy.restore();
   });
 
   it('creates a collapsed UnmuteIcon', function() {


### PR DESCRIPTION
This update fixes an issue in which clicking on the "unmute" button during an ad would also trigger a click on the `AdScreen`, which in turn would trigger the ad's clickthrough.

**Note:** I don't think this is an urgent issue so it's probably better not to include this on the candidate build yet. 