### PR TITLE
[bugfix/PBW-7632] unmute btn is clickable

### DIFF
--- a/scss/components/_unmute.scss
+++ b/scss/components/_unmute.scss
@@ -13,6 +13,10 @@
   background-color: rgba(255, 255, 255, 0.9);
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.3);
   z-index: $zindex-unmute;
+  &:active, &:focus, &:hover {
+    outline: 0;
+    outline-offset: 0;
+  }
 }
 
 .oo-unmute.oo-expanded {
@@ -37,4 +41,5 @@
   width: 24px;
   height: 24px;
   padding-left: 4px;
+  pointer-events: auto;
 }


### PR DESCRIPTION
The problem:
Screens has button mute/unmute on the left top of the screen.
When ad is playing and an user click on the btn Instead of muting/unmuting the video, ad url is opened.

My solution:
On ad-screen "pointer-events" is "none";
This value is inherited to the btn.
So, I changed this value for the btn, and remove blue border when the element is in focus.