### PR TITLE
[PLAYER-4596] After trying watching DASH video on unsupported environment, LANGUAGE BUTTON disappears

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -259,8 +259,6 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
         _.bind(this.setVrViewingDirection, this)
       );
       this.mb.subscribe(OO.EVENTS.RECREATING_UI, 'customerUi', _.bind(this.recreatingUI, this));
-      this.mb.subscribe(OO.EVENTS.MULTI_AUDIO_FETCHED, 'customerUi', _.bind(this.onMultiAudioFetched, this));
-      this.mb.subscribe(OO.EVENTS.MULTI_AUDIO_CHANGED, 'customerUi', _.bind(this.onMultiAudioChanged, this));
       this.mb.subscribe(
         OO.EVENTS.POSITION_IN_PLAYLIST_DETERMINED,
         'customerUi',
@@ -300,6 +298,8 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
           'customerUi',
           _.bind(this.onClosedCaptionsInfoAvailable, this)
         );
+        this.mb.subscribe(OO.EVENTS.MULTI_AUDIO_FETCHED, 'customerUi', _.bind(this.onMultiAudioFetched, this));
+        this.mb.subscribe(OO.EVENTS.MULTI_AUDIO_CHANGED, 'customerUi', _.bind(this.onMultiAudioChanged, this));
         this.mb.subscribe(
           OO.EVENTS.BITRATE_INFO_AVAILABLE,
           'customerUi',


### PR DESCRIPTION
The problem:
If an user clicked on video with unsupported format for the browser and after that he chose another video from playlist, MA icon would not shown.

My solution:
We have to subscribe to events for MA each time when embed code was changed, because even in case if playback was destroyed, function init() would not be called.

These changes are not covered by tests.