### PR TITLE
Bugfix/player 4575 Total Duration of asset is not shown on start screen, it is shown as 0:00

### DIFF
--- a/js/components/accessibilityControls.js
+++ b/js/components/accessibilityControls.js
@@ -275,8 +275,8 @@ AccessibilityControls.prototype = {
 
     // Calculate the new playhead
     var delta = shiftSeconds * shiftSign * seekRate;
-    var seekTo = Utils.ensureNumber(this.controller.skin.state.currentPlayhead, 0) + delta;
-    seekTo = Utils.constrainToRange(seekTo, 0, this.controller.skin.state.duration);
+    let seekTo = Utils.ensureNumber(this.controller.skin.currentPlayhead, 0) + delta;
+    seekTo = Utils.constrainToRange(seekTo, 0, this.controller.skin.duration);
 
     // Refresh UI and then instruct the player to seek
     this.controller.updateSeekingPlayhead(seekTo);

--- a/js/controller.js
+++ b/js/controller.js
@@ -1432,7 +1432,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
           this.state.adStartTime = 0;
         }
         this.state.adEndTime = this.state.adStartTime + this.state.adVideoDuration;
-        this.skin.state.currentPlayhead = 0;
+        this.skin.currentPlayhead = 0;
         this.removeBlur();
         this.renderSkin();
       }
@@ -2708,8 +2708,8 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
     },
 
     updateSeekingPlayhead: function(playhead) {
-      playhead = Math.min(Math.max(0, playhead), this.skin.state.duration);
-      this.skin.updatePlayhead(playhead, this.skin.state.duration, this.skin.state.buffered);
+      playhead = Math.min(Math.max(0, playhead), this.skin.duration);
+      this.skin.updatePlayhead(playhead, this.skin.duration, this.skin.buffered);
     },
 
     hideVolumeSliderBar: function() {

--- a/js/skin.js
+++ b/js/skin.js
@@ -42,9 +42,11 @@ const Skin = createReactClass({
 
   getInitialState: function() {
     this.overlayRenderingEventSent = false;
+    this.duration = 0;
+    this.currentPlayhead = 0;
+    this.buffered;
     return {
       screenToShow: null,
-      currentPlayhead: 0,
       discoveryData: null,
       isVrMouseDown: false,
       isVrMouseMove: false,
@@ -85,12 +87,10 @@ const Skin = createReactClass({
   },
 
   updatePlayhead: function(newPlayhead, newDuration, newBuffered, adPlayhead) {
-    this.setState({
-      currentPlayhead: Utils.ensureNumber(newPlayhead, this.state.currentPlayhead),
-      duration: Utils.ensureNumber(newDuration, this.state.duration),
-      buffered: Utils.ensureNumber(newBuffered, this.state.buffered),
-      currentAdPlayhead: Utils.ensureNumber(adPlayhead, this.state.currentAdPlayhead)
-    });
+    this.duration = Utils.ensureNumber(newDuration, this.duration);
+    this.buffered = Utils.ensureNumber(newBuffered, this.buffered);
+    this.currentAdPlayhead = Utils.ensureNumber(adPlayhead, this.currentAdPlayhead);
+    this.currentPlayhead = Utils.ensureNumber(newPlayhead, this.currentPlayhead);
   },
 
   /**
@@ -101,13 +101,13 @@ const Skin = createReactClass({
   getTotalTime: function() {
     let totalTime = 0;
     if (
-      this.state.duration === null ||
-      typeof this.state.duration === 'undefined' ||
-      this.state.duration === ''
+      this.duration === null ||
+      typeof this.duration === 'undefined' ||
+      this.duration === ''
     ) {
       totalTime = Utils.formatSeconds(0);
     } else {
-      totalTime = Utils.formatSeconds(this.state.duration);
+      totalTime = Utils.formatSeconds(this.duration);
     }
     return totalTime;
   },
@@ -119,14 +119,14 @@ const Skin = createReactClass({
    * @returns {string} The current playhead time in (HH:)MM:SS format or null if the current playhead is invalid or timeshift is 0
    */
   getPlayheadTime: function() {
-    let playheadTime = isFinite(parseInt(this.state.currentPlayhead)) ?
-      Utils.formatSeconds(parseInt(this.state.currentPlayhead))
+    let playheadTime = isFinite(parseInt(this.currentPlayhead)) ?
+      Utils.formatSeconds(parseInt(this.currentPlayhead))
       :
       null;
-    var isLiveStream = this.state.isLiveStream;
-    var timeShift = this.state.currentPlayhead - this.state.duration;
+    const isLiveStream = this.state.isLiveStream;
+    const timeShift = this.currentPlayhead - this.duration;
     // checking timeShift < 1 seconds (not === 0) as processing of the click after we rewinded and then went live may take some time
-    var isLiveNow = Math.abs(timeShift) < 1;
+    const isLiveNow = Math.abs(timeShift) < 1;
     playheadTime = isLiveStream ?
       (isLiveNow ? null : Utils.formatSeconds(timeShift))
       :
@@ -416,11 +416,11 @@ const Skin = createReactClass({
               <AudioOnlyScreen
                 {...this.props}
                 contentTree={this.state.contentTree}
-                currentPlayhead={this.state.currentPlayhead}
-                duration={this.state.duration}
+                currentPlayhead={this.currentPlayhead}
+                duration={this.duration}
                 totalTime={this.getTotalTime()}
                 playheadTime={this.getPlayheadTime()}
-                buffered={this.state.buffered}
+                buffered={this.buffered}
                 fullscreen={this.state.fullscreen}
                 playerState={this.state.playerState}
                 seeking={this.state.seeking}
@@ -489,11 +489,11 @@ const Skin = createReactClass({
                 handleTouchEndOnWindow={this.handleTouchEndOnWindow}
                 isVrMouseMove={this.state.isVrMouseMove}
                 contentTree={this.state.contentTree}
-                currentPlayhead={this.state.currentPlayhead}
-                duration={this.state.duration}
+                currentPlayhead={this.currentPlayhead}
+                duration={this.duration}
                 totalTime={this.getTotalTime()}
                 playheadTime={this.getPlayheadTime()}
-                buffered={this.state.buffered}
+                buffered={this.buffered}
                 fullscreen={this.state.fullscreen}
                 playerState={this.state.playerState}
                 seeking={this.state.seeking}
@@ -529,11 +529,11 @@ const Skin = createReactClass({
                   playerState={this.state.playerState}
                   isLiveStream={this.state.isLiveStream}
                   a11yControls={this.props.controller.accessibilityControls}
-                  currentPlayhead={this.state.currentPlayhead}
-                  duration={this.state.duration}
+                  currentPlayhead={this.currentPlayhead}
+                  duration={this.duration}
                   totalTime={this.getTotalTime()}
                   playheadTime={this.getPlayheadTime()}
-                  buffered={this.state.buffered}
+                  buffered={this.buffered}
                   responsiveView={this.state.responsiveId}
                   componentWidth={this.state.componentWidth}
                 />
@@ -552,12 +552,12 @@ const Skin = createReactClass({
                 handleTouchEndOnWindow={this.handleTouchEndOnWindow}
                 isVrMouseMove={this.state.isVrMouseMove}
                 contentTree={this.state.contentTree}
-                currentPlayhead={this.state.currentPlayhead}
+                currentPlayhead={this.currentPlayhead}
                 playerState={this.state.playerState}
-                duration={this.state.duration}
+                duration={this.duration}
                 totalTime={this.getTotalTime()}
                 playheadTime={this.getPlayheadTime()}
-                buffered={this.state.buffered}
+                buffered={this.buffered}
                 pauseAnimationDisabled={this.state.pauseAnimationDisabled}
                 fullscreen={this.state.fullscreen}
                 seeking={this.state.seeking}
@@ -577,11 +577,11 @@ const Skin = createReactClass({
                 {...this.props}
                 contentTree={this.state.contentTree}
                 discoveryData={this.state.discoveryData}
-                currentPlayhead={this.state.currentPlayhead}
-                duration={this.state.duration}
+                currentPlayhead={this.currentPlayhead}
+                duration={this.duration}
                 totalTime={this.getTotalTime()}
                 playheadTime={this.getPlayheadTime()}
-                buffered={this.state.buffered}
+                buffered={this.buffered}
                 fullscreen={this.state.fullscreen}
                 playerState={this.state.playerState}
                 seeking={this.state.seeking}
@@ -599,13 +599,13 @@ const Skin = createReactClass({
                 {...this.props}
                 contentTree={this.state.contentTree}
                 currentAdsInfo={this.state.currentAdsInfo}
-                currentPlayhead={this.state.currentPlayhead}
-                currentAdPlayhead={this.state.currentAdPlayhead}
+                currentPlayhead={this.currentPlayhead}
+                currentAdPlayhead={this.currentAdPlayhead}
                 fullscreen={this.state.fullscreen}
                 playerState={this.state.playerState}
-                duration={this.state.duration}
+                duration={this.duration}
                 adVideoDuration={this.props.controller.state.adVideoDuration}
-                buffered={this.state.buffered}
+                buffered={this.buffered}
                 seeking={this.state.seeking}
                 responsiveView={this.state.responsiveId}
                 componentWidth={this.state.componentWidth}

--- a/tests/components/accessibilityControls-test.js
+++ b/tests/components/accessibilityControls-test.js
@@ -308,44 +308,44 @@ describe('AccessibilityControls', function() {
       });
 
       it('should seek the specified amount of seconds forward', function() {
-        mockCtrl.skin.state.duration = 60;
-        mockCtrl.skin.state.currentPlayhead = 0;
+        mockCtrl.skin.duration = 60;
+        mockCtrl.skin.currentPlayhead = 0;
         a11yCtrls.seekBy(5, true);
         expect(newPlayhead).toBe(5);
       });
 
       it('should seek back the specified amount of seconds', function() {
-        mockCtrl.skin.state.duration = 60;
-        mockCtrl.skin.state.currentPlayhead = 10;
+        mockCtrl.skin.duration = 60;
+        mockCtrl.skin.currentPlayhead = 10;
         a11yCtrls.seekBy(5, false);
         expect(newPlayhead).toBe(5);
       });
 
       it('should handle negative values gracefully by inverting the direction of the seek', function() {
-        mockCtrl.skin.state.duration = 60;
-        mockCtrl.skin.state.currentPlayhead = 10;
+        mockCtrl.skin.duration = 60;
+        mockCtrl.skin.currentPlayhead = 10;
         a11yCtrls.seekBy(-5, false);
         expect(newPlayhead).toBe(15);
       });
 
       it('should not seek past the video\'s duration', function() {
-        mockCtrl.skin.state.duration = 60;
-        mockCtrl.skin.state.currentPlayhead = 10;
+        mockCtrl.skin.duration = 60;
+        mockCtrl.skin.currentPlayhead = 10;
         a11yCtrls.seekBy(120, true);
-        expect(newPlayhead).toBe(mockCtrl.skin.state.duration);
+        expect(newPlayhead).toBe(mockCtrl.skin.duration);
       });
 
       it('should not seek past the video\'s start time', function() {
-        mockCtrl.skin.state.duration = 60;
-        mockCtrl.skin.state.currentPlayhead = 30;
+        mockCtrl.skin.duration = 60;
+        mockCtrl.skin.currentPlayhead = 30;
         a11yCtrls.seekBy(120, false);
         expect(newPlayhead).toBe(0);
       });
 
       it('should not seek when seeking is disabled', function() {
         mockCtrl.state.screenToShow = CONSTANTS.SCREEN.AD_SCREEN;
-        mockCtrl.skin.state.duration = 60;
-        mockCtrl.skin.state.currentPlayhead = 0;
+        mockCtrl.skin.duration = 60;
+        mockCtrl.skin.currentPlayhead = 0;
         a11yCtrls.seekBy(5, true);
         expect(newPlayhead).toBeNull();
       });

--- a/tests/skin-test.js
+++ b/tests/skin-test.js
@@ -307,35 +307,35 @@ describe('Methods tests', function() {
   });
 
   it('getTotalTime should return the duration of the video', () => {
-    skin.state.duration = 60;
+    skin.duration = 60;
     expect(skin.getTotalTime()).toBe("01:00");
 
-    skin.state.duration = 3600;
+    skin.duration = 3600;
     expect(skin.getTotalTime()).toBe("01:00:00");
 
-    skin.state.duration = null;
+    skin.duration = null;
     expect(skin.getTotalTime()).toBe("00:00");
 
-    delete skin.state.duration;
+    delete skin.duration;
     expect(skin.getTotalTime()).toBe("00:00");
   });
 
   it('getPlayheadTime should return the current playhead of the video', () => {
-    skin.state.currentPlayhead = 120;
+    skin.currentPlayhead = 120;
     expect(skin.getPlayheadTime()).toBe("02:00");
 
-    skin.state.currentPlayhead = 7200;
+    skin.currentPlayhead = 7200;
     expect(skin.getPlayheadTime()).toBe("02:00:00");
 
-    skin.state.currentPlayhead = null;
+    skin.currentPlayhead = null;
     expect(skin.getPlayheadTime()).toBe(null);
 
-    delete skin.state.currentPlayhead;
+    delete skin.currentPlayhead;
     expect(skin.getPlayheadTime()).toBe(null);
 
     skin.state.isLiveStream = true;
-    skin.state.currentPlayhead = 120;
-    skin.state.duration = 60;
+    skin.currentPlayhead = 120;
+    skin.duration = 60;
     expect(skin.getPlayheadTime()).toBe("01:00");
   });
 


### PR DESCRIPTION
The problem:
Total Duration of asset is not shown on start screen.

The reason:
The value for "duration" was in State, and it was changed in "updatePlayhead", where new state value was count within function Utils.ensureNumber using itself.

The solution:
Do not store values that we pass as arguments to a function in the state  

Unit tests passed