### PR TITLE
[bugfix/PLAYER-4575] Total Duration of asset is not shown on start screen, it is shown as 0:00

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1215,7 +1215,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
         OO.log('popping queued update');
         this.skin.updatePlayhead.apply(this.skin, this.state.queuedPlayheadUpdate).then(() => {
           this.state.queuedPlayheadUpdate = null;
-        }).catch(OO.log('onSeeked: Could not set new state for skin'));
+        }).catch(() => {OO.log('onSeeked: Could not set new state for skin')});
       }
       if (Utils.isIos() && this.state.screenToShow === CONSTANTS.SCREEN.END_SCREEN && this.state.fullscreen) {
         this.state.pauseAnimationDisabled = true;

--- a/js/controller.js
+++ b/js/controller.js
@@ -681,8 +681,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
       this.state.playerState = CONSTANTS.STATE.START;
       var duration = Utils.ensureNumber(contentTree.duration, 0) / 1000;
       if (this.skin) {
-        let promise = this.skin.updatePlayhead(null, duration);
-        promise.then(() => {
+        this.skin.updatePlayhead(null, duration).then(() => {
           this.renderSkin({ contentTree: contentTree });
         });
       }

--- a/js/skin.js
+++ b/js/skin.js
@@ -86,7 +86,7 @@ const Skin = createReactClass({
   },
 
   updatePlayhead: function(newPlayhead, newDuration, newBuffered, adPlayhead) {
-    let promise = new Promise((resolve) => {
+    return new Promise((resolve) => {
       this.setState(function(prevState) {
         const duration = Utils.ensureNumber(newDuration, prevState.duration);
         const totalTime = this.getTotalTime(duration);
@@ -100,11 +100,8 @@ const Skin = createReactClass({
           currentAdPlayhead,
           totalTime
         }
-      }, function() {
-        resolve(true);
-      });
+      }, resolve);
     });
-    return promise;
   },
   /**
    * Gets the total time of the video in (HH:)MM:SS format

--- a/js/skin.js
+++ b/js/skin.js
@@ -43,6 +43,7 @@ const Skin = createReactClass({
   getInitialState: function() {
     this.overlayRenderingEventSent = false;
     return {
+      totalTime: '00:00',
       screenToShow: null,
       currentPlayhead: 0,
       discoveryData: null,
@@ -85,30 +86,36 @@ const Skin = createReactClass({
   },
 
   updatePlayhead: function(newPlayhead, newDuration, newBuffered, adPlayhead) {
-    this.setState({
-      currentPlayhead: Utils.ensureNumber(newPlayhead, this.state.currentPlayhead),
-      duration: Utils.ensureNumber(newDuration, this.state.duration),
-      buffered: Utils.ensureNumber(newBuffered, this.state.buffered),
-      currentAdPlayhead: Utils.ensureNumber(adPlayhead, this.state.currentAdPlayhead)
+    let promise = new Promise((resolve, reject) => {
+      this.setState(function(prevState) {
+        const duration = Utils.ensureNumber(newDuration, prevState.duration);
+        const totalTime = this.getTotalTime(duration);
+        const currentPlayhead = Utils.ensureNumber(newPlayhead, prevState.currentPlayhead);
+        const buffered = Utils.ensureNumber(newBuffered, prevState.buffered);
+        const currentAdPlayhead = Utils.ensureNumber(adPlayhead, prevState.currentAdPlayhead);
+        return {
+          currentPlayhead: currentPlayhead,
+          duration: duration,
+          buffered: buffered,
+          currentAdPlayhead: currentAdPlayhead,
+          totalTime: totalTime
+        }
+      });
+      resolve(true);
+      reject(false);
     });
+    return promise;
   },
-
   /**
    * Gets the total time of the video in (HH:)MM:SS format
    * @private
+   * @param {number} duration - time to format HH:mm
    * @returns {string} The total time of the video in (HH:)MM:SS format
    */
-  getTotalTime: function() {
-    let totalTime = 0;
-    if (
-      this.state.duration === null ||
-      typeof this.state.duration === 'undefined' ||
-      this.state.duration === ''
-    ) {
-      totalTime = Utils.formatSeconds(0);
-    } else {
-      totalTime = Utils.formatSeconds(this.state.duration);
-    }
+  getTotalTime: function(duration) {
+    let totalTime = '00:00';
+    const ensureNumberDuration = Utils.ensureNumber(duration) ? Utils.ensureNumber(duration) : 0;
+    totalTime = Utils.formatSeconds(ensureNumberDuration);
     return totalTime;
   },
 
@@ -337,7 +344,6 @@ const Skin = createReactClass({
    * sets current direction for vr video (it is necessary for tilting)
    * when touchend is called on selected screen
    * @public
-   * @param {Event} event - event object
    */
   handleTouchEndOnWindow: function() {
     if (this.props.controller.videoVr) { // only for vr on mobile
@@ -418,7 +424,7 @@ const Skin = createReactClass({
                 contentTree={this.state.contentTree}
                 currentPlayhead={this.state.currentPlayhead}
                 duration={this.state.duration}
-                totalTime={this.getTotalTime()}
+                totalTime={this.state.totalTime}
                 playheadTime={this.getPlayheadTime()}
                 buffered={this.state.buffered}
                 fullscreen={this.state.fullscreen}
@@ -491,7 +497,7 @@ const Skin = createReactClass({
                 contentTree={this.state.contentTree}
                 currentPlayhead={this.state.currentPlayhead}
                 duration={this.state.duration}
-                totalTime={this.getTotalTime()}
+                totalTime={this.state.totalTime}
                 playheadTime={this.getPlayheadTime()}
                 buffered={this.state.buffered}
                 fullscreen={this.state.fullscreen}
@@ -531,7 +537,7 @@ const Skin = createReactClass({
                   a11yControls={this.props.controller.accessibilityControls}
                   currentPlayhead={this.state.currentPlayhead}
                   duration={this.state.duration}
-                  totalTime={this.getTotalTime()}
+                  totalTime={this.state.totalTime}
                   playheadTime={this.getPlayheadTime()}
                   buffered={this.state.buffered}
                   responsiveView={this.state.responsiveId}
@@ -555,7 +561,7 @@ const Skin = createReactClass({
                 currentPlayhead={this.state.currentPlayhead}
                 playerState={this.state.playerState}
                 duration={this.state.duration}
-                totalTime={this.getTotalTime()}
+                totalTime={this.state.totalTime}
                 playheadTime={this.getPlayheadTime()}
                 buffered={this.state.buffered}
                 pauseAnimationDisabled={this.state.pauseAnimationDisabled}
@@ -579,7 +585,7 @@ const Skin = createReactClass({
                 discoveryData={this.state.discoveryData}
                 currentPlayhead={this.state.currentPlayhead}
                 duration={this.state.duration}
-                totalTime={this.getTotalTime()}
+                totalTime={this.state.totalTime}
                 playheadTime={this.getPlayheadTime()}
                 buffered={this.state.buffered}
                 fullscreen={this.state.fullscreen}

--- a/js/skin.js
+++ b/js/skin.js
@@ -86,7 +86,7 @@ const Skin = createReactClass({
   },
 
   updatePlayhead: function(newPlayhead, newDuration, newBuffered, adPlayhead) {
-    let promise = new Promise((resolve, reject) => {
+    let promise = new Promise((resolve) => {
       this.setState(function(prevState) {
         const duration = Utils.ensureNumber(newDuration, prevState.duration);
         const totalTime = this.getTotalTime(duration);
@@ -94,15 +94,15 @@ const Skin = createReactClass({
         const buffered = Utils.ensureNumber(newBuffered, prevState.buffered);
         const currentAdPlayhead = Utils.ensureNumber(adPlayhead, prevState.currentAdPlayhead);
         return {
-          currentPlayhead: currentPlayhead,
-          duration: duration,
-          buffered: buffered,
-          currentAdPlayhead: currentAdPlayhead,
-          totalTime: totalTime
+          currentPlayhead,
+          duration,
+          buffered,
+          currentAdPlayhead,
+          totalTime
         }
+      }, function() {
+        resolve(true);
       });
-      resolve(true);
-      reject(false);
     });
     return promise;
   },

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -108,10 +108,14 @@ describe('Controller', function() {
     controller.skin = {
       state: {},
       updatePlayhead: function(currentPlayhead, duration, buffered, currentAdPlayhead) {
-        this.state.currentPlayhead = currentPlayhead;
-        this.state.duration = duration;
-        this.state.buffered = buffered;
-        this.state.currentAdPlayhead = currentAdPlayhead;
+        return new Promise((resolve, reject) => {
+          this.state.currentPlayhead = currentPlayhead;
+          this.state.duration = duration;
+          this.state.buffered = buffered;
+          this.state.currentAdPlayhead = currentAdPlayhead;
+          resolve(true);
+          reject(false);
+        });
       },
       props: {
         skinConfig: JSON.parse(JSON.stringify(skinJson))

--- a/tests/skin-test.js
+++ b/tests/skin-test.js
@@ -308,16 +308,16 @@ describe('Methods tests', function() {
 
   it('getTotalTime should return the duration of the video', () => {
     skin.state.duration = 60;
-    expect(skin.getTotalTime()).toBe("01:00");
+    expect(skin.getTotalTime(skin.state.duration)).toBe("01:00");
 
     skin.state.duration = 3600;
-    expect(skin.getTotalTime()).toBe("01:00:00");
+    expect(skin.getTotalTime(skin.state.duration)).toBe("01:00:00");
 
     skin.state.duration = null;
-    expect(skin.getTotalTime()).toBe("00:00");
+    expect(skin.getTotalTime(skin.state.duration)).toBe("00:00");
 
     delete skin.state.duration;
-    expect(skin.getTotalTime()).toBe("00:00");
+    expect(skin.getTotalTime(skin.state.duration)).toBe("00:00");
   });
 
   it('getPlayheadTime should return the current playhead of the video', () => {


### PR DESCRIPTION
The problem:
Total Duration of asset is not shown on start screen.

The reason:
The value for "duration" was in State, and it was changed in "updatePlayhead", where new state value was count within function Utils.ensureNumber using itself.

The solution:
Return promise from updatePlayhead and resolve it once setState in there is done

Unit tests passed