### PR TITLE
[bugfix/PWB-7632] pointer-events for oo-unmute in right place

### DIFF
--- a/scss/components/_unmute.scss
+++ b/scss/components/_unmute.scss
@@ -13,6 +13,7 @@
   background-color: rgba(255, 255, 255, 0.9);
   box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.3);
   z-index: $zindex-unmute;
+  pointer-events: auto;
   &:active, &:focus, &:hover {
     outline: 0;
     outline-offset: 0;
@@ -41,5 +42,4 @@
   width: 24px;
   height: 24px;
   padding-left: 4px;
-  pointer-events: auto;
 }


### PR DESCRIPTION
The style was placed in right placed (from inner div to outer one).