### PR TITLE
Bugfix PBW-7648

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1433,7 +1433,6 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
         this.state.adEndTime = this.state.adStartTime + this.state.adVideoDuration;
         this.skin.state.currentPlayhead = 0;
         this.removeBlur();
-        this.renderSkin();
       }
     },
 


### PR DESCRIPTION
Removed renderSkin call from onWillPlaySingleAd function

This fixes https://jira.corp.ooyala.com/browse/PBW-7648 for the case with 'vast ads' and bitmovin.
