### PR TITLE
force `renderSkin` to show end screen after the video has been played

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1091,6 +1091,7 @@ OO.plugin('Html5Skin', function(OO, _, $, W) {
         this.state.screenToShow = CONSTANTS.SCREEN.SHARE_SCREEN;
       } else {
         this.state.screenToShow = CONSTANTS.SCREEN.END_SCREEN;
+        this.renderSkin();
         //TODO: END_SCREEN_SHOWN is not consumed by anyone, should we remove? If not, should
         //we publish this when the end screen is actually shown?
         this.mb.publish(OO.EVENTS.END_SCREEN_SHOWN);


### PR DESCRIPTION
There's a comment below about `END_SCREEN_SHOWN`. Does anybody have an idea?
Also we need a plan how to deal with event system. Now it's a mess.