### PR TITLE
[bugfix/PBW-7632] pointer-events: auto for skip btn

### DIFF
--- a/scss/components/_ad-panel.scss
+++ b/scss/components/_ad-panel.scss
@@ -95,6 +95,7 @@
     .oo-skip-button.oo-enabled {
       opacity: 1;
       cursor: pointer;
+      pointer-events: auto;
     }
   }
 }


### PR DESCRIPTION
A value for "pointer-events" for skip btn should be "auto" instead of inheritable value "none" to be clickable.