### PR TITLE
bugfix/PBW-7731 How to set loading bar at the black screen

### DIFF
--- a/js/views/pauseScreen.js
+++ b/js/views/pauseScreen.js
@@ -16,6 +16,7 @@ const CONSTANTS = require('./../constants/constants');
 const ViewControlsVr = require('../components/viewControlsVr');
 const withAutoHide = require('./higher-order/withAutoHide.js');
 const CastPanel = require('../components/castPanel');
+const Spinner = require('../components/spinner');
 
 
 /**
@@ -351,6 +352,12 @@ class PauseScreen extends React.Component {
             device={this.props.controller.state.cast.device}
             className={castPanelClass}
           />
+        }
+
+        {
+          this.props.controller.state.buffering || this.props.buffered === 0 ?
+            <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url} />
+           : null
         }
 
         {viewControlsVr}

--- a/js/views/playingScreen.js
+++ b/js/views/playingScreen.js
@@ -437,9 +437,11 @@ class PlayingScreen extends React.Component {
           />
         }
 
-        {this.props.controller.state.buffering ? (
-          <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url} />
-        ) : null}
+        {
+          this.props.controller.state.buffering || this.props.buffered === 0 ?
+            <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url} />
+            : null
+        }
 
         {viewControlsVr}
 

--- a/tests/views/pauseScreen-test.js
+++ b/tests/views/pauseScreen-test.js
@@ -6,14 +6,15 @@ jest
 .dontMock('../../js/components/utils')
 .dontMock('classnames');
 
-var React = require('react');
-var sinon = require('sinon');
-var Enzyme = require('enzyme');
-var ClassNames = require('classnames');
-var skinConfig = require('../../config/skin.json');
-var SkipControls = require('../../js/components/skipControls');
-var Utils = require('../../js/components/utils');
-var CONSTANTS = require('../../js/constants/constants');
+const React = require('react');
+const sinon = require('sinon');
+const Enzyme = require('enzyme');
+const ClassNames = require('classnames');
+const skinConfig = require('../../config/skin.json');
+const SkipControls = require('../../js/components/skipControls');
+const Utils = require('../../js/components/utils');
+const CONSTANTS = require('../../js/constants/constants');
+const Spinner = require('../../js/components/spinner');
 
 const CastPanel = require('../../js/components/castPanel');
 
@@ -210,6 +211,49 @@ describe('PauseScreen', function() {
     mockSkinConfig.skipControls.enabled = true;
     wrapper = Enzyme.mount(component);
     expect(wrapper.find(SkipControls).length).toBe(1);
+  });
+
+  describe('Spinner tests', function() {
+    const createPauseScreen = (buffered, buffering) => {
+      mockController.state.buffering = buffering;
+      return (
+        Enzyme.mount(
+          <PauseScreen
+            responsiveView={ "md" }
+            skinConfig={ mockSkinConfig }
+            controller={ mockController }
+            contentTree={ mockContentTree }
+            handleVrPlayerClick={ () => {} }
+            closedCaptionOptions={ { cueText: 'sample text' } }
+            currentPlayhead={ 0 }
+            playerState={ CONSTANTS.STATE.PAUSE }
+            totalTime={ "60:00" }
+            playheadTime={ "00:00" }
+            buffered={ buffered }
+          />
+        )
+      );
+    };
+
+    it('Spinner should not be shown when buffering is false and buffered !== 0', function() {
+      let wrapper = createPauseScreen(2, false);
+      expect(wrapper.find(Spinner).length).toBe(0);
+    });
+
+    it('Spinner should not be shown when buffering is false and buffered === null', function(){
+      let wrapper = createPauseScreen(null, false);
+      expect(wrapper.find(Spinner).length).toBe(0);
+    });
+
+    it('Spinner should be shown when buffered === 0', function() {
+      let wrapper = createPauseScreen(0, false);
+      expect(wrapper.find(Spinner).length).toBe(1);
+    });
+
+    it('Spinner should be shown when buffering is true even if buffered !== 0', function(){
+      let wrapper = createPauseScreen(2, true);
+      expect(wrapper.find(Spinner).length).toBe(1);
+    });
   });
 
   it('[Chromecast] should not display cast panel', function(){

--- a/tests/views/playingScreen-test.js
+++ b/tests/views/playingScreen-test.js
@@ -5,15 +5,16 @@ jest
 .dontMock('../../js/components/higher-order/accessibleMenu')
 .dontMock('../../js/components/higher-order/preserveKeyboardFocus');
 
-var React = require('react');
-var ReactDOM = require('react-dom');
-var Enzyme = require('enzyme');
-var UnmuteIcon = require('../../js/components/unmuteIcon');
-var skinConfig = require('../../config/skin.json');
-var SkipControls = require('../../js/components/skipControls');
-var TextTrackPanel = require('../../js/components/textTrackPanel');
-var Utils = require('../../js/components/utils');
-var CONSTANTS = require('../../js/constants/constants');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const Enzyme = require('enzyme');
+const UnmuteIcon = require('../../js/components/unmuteIcon');
+const skinConfig = require('../../config/skin.json');
+const SkipControls = require('../../js/components/skipControls');
+const TextTrackPanel = require('../../js/components/textTrackPanel');
+const Utils = require('../../js/components/utils');
+const CONSTANTS = require('../../js/constants/constants');
+const Spinner = require('../../js/components/spinner');
 
 const CastPanel = require('../../js/components/castPanel');
 
@@ -629,6 +630,49 @@ describe('PlayingScreen', function() {
     mockController.state.controlBarVisible = true;
     wrapper = renderPlayingScreen();
     expect(wrapper.find(TextTrackPanel).props().isInBackground).toBe(true);
+  });
+
+  describe('Spinner tests', function() {
+    const createPlayingScreen = (buffered, buffering) => {
+      mockController.state.buffering = buffering;
+      return (
+        Enzyme.mount(
+          <PlayingScreen
+            controller={ mockController }
+            skinConfig={ mockSkinConfig }
+            closedCaptionOptions={ {} }
+            responsiveView="md"
+            currentPlayhead={ 0 }
+            handleVrPlayerMouseUp={() => {}}
+            playerState={ CONSTANTS.STATE.PLAYING }
+            totalTime={ "60:00" }
+            playheadTime={ "00:00" }
+            contentTree={ mockController.state.contentTree }
+            buffered={ buffered }
+          />
+        )
+      );
+    };
+
+    it('Spinner should not be shown when buffering is false and buffered !== 0', function(){
+      let wrapper = createPlayingScreen(2, false);
+      expect(wrapper.find(Spinner).length).toBe(0);
+    });
+
+    it('Spinner should not be shown when buffering is false and buffered === null', function(){
+      let wrapper = createPlayingScreen(null, false);
+      expect(wrapper.find(Spinner).length).toBe(0);
+    });
+
+    it('Spinner should be shown when buffered === 0', function(){
+      let wrapper = createPlayingScreen(0, false);
+      expect(wrapper.find(Spinner).length).toBe(1);
+    });
+
+    it('Spinner should be shown when buffering is true even if buffered !== 0', function(){
+      let wrapper = createPlayingScreen(2, true);
+      expect(wrapper.find(Spinner).length).toBe(1);
+    });
   });
 
   it('should cancel auto hide timer when mouse is over skip controls when they mount', function() {


### PR DESCRIPTION
After an ad value for buffering is false.
And sometimes we do not have any events when an ad is ended and a main video is not playing yet. It is become visible especially with bad internet connection (for exemple, slow 3g).
So in this case if nothing buffered yet, but buffering state is false we should show spinner.
Also this behavior was added for pauseScreen.

Unit tests passed.