### PR TITLE
[PLAYER-4881] hide video element for audio only asset

### DIFF
--- a/scss/base/_normalize.scss
+++ b/scss/base/_normalize.scss
@@ -49,8 +49,13 @@ section {
 //canvas,
 //progress,
 video {
-  display: block; // 1
+  display: none;
   vertical-align: baseline; // 2
+}
+.oo-video-player {
+  video {
+    display: block; // 1
+  }
 }
 
 //


### PR DESCRIPTION
Now if audio stream contains video it will be shown. This solution is a workaround, SAS shouldn't send video chunks in audio only stream
`.oo-video-player` class appears only for video assets: https://github.com/ooyala/html5-skin/blob/master/js/controller.js#L1714-L1717