### PR TITLE
[PLAYER-4366] Chromecast auto rejoin fix

### DIFF
--- a/js/views/pauseScreen.js
+++ b/js/views/pauseScreen.js
@@ -355,7 +355,7 @@ class PauseScreen extends React.Component {
         }
 
         {
-          this.props.controller.state.buffering || this.props.buffered === 0 ?
+          this.props.controller.state.buffering || !this.props.controller.state.cast.connected && this.props.buffered === 0 ?
             <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url} />
            : null
         }


### PR DESCRIPTION
when casting if I pause video playback and then reload current tab pauseScreen will be rendered with a Spinner (since the buffer prop is 0 until playback's started)

https://jira.corp.ooyala.com/browse/PLAYER-4366

Version:4.30.9
Status: Failed
Debug link: https://tinyurl.com/ya2rd85q

Steps:
1. Open the debug link
2. Connect to chromecast
3. Video plays on receiver
4. Pause the video on sender 
5. Refresh the page
6. Player rejoins the session but loading spinner is still shown in player. loading spinner disappears on clicking on 'Play' button(Refer to video attached)