### PR TITLE
[bugfix/PLAYER-4606] Use the browser settings over skin.json

### DIFF
--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -714,13 +714,7 @@ var Utils = {
     if ( !(availableLanguageList && Array.isArray(availableLanguageList) && languageCode) ) {
       return false;
     }
-    for (let index = availableLanguageList.length - 1; index >= 0; index--) {
-      let availableLanguageCode = availableLanguageList[index].language;
-      if (languageCode === availableLanguageCode) {
-        return true;
-      }
-    }
-    return false;
+    return !!availableLanguageList.find(languageObj => languageObj.language === languageCode);
   },
 
   /**

--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -635,27 +635,23 @@ var Utils = {
    * @returns {String} The ISO 639-1 code of the language to use or an empty string
    */
   getLanguageToUse: function(skinConfig) {
-    let language = '';
-    if (skinConfig) {
-      const localization = skinConfig.localization;
-
-      const userBrowserLanguage = this.getUserBrowserLanguage();
-
-      if (userBrowserLanguage && localization) {
-        let isLanguageCodeInAvailablelLanguageFile = this.isLanguageCodeInAvailablelLanguageFile(
-          localization.availableLanguageFile, userBrowserLanguage
-        );
-        if (isLanguageCodeInAvailablelLanguageFile) {
-          language = userBrowserLanguage;
-        } else {
-          language = this.getDefaultLanguage(localization);
-        }
-      } else {
-        language = this.getDefaultLanguage(localization);
-      }
+    if (!skinConfig) {
+      return '';
     }
 
-    return language;
+    const localization = skinConfig.localization;
+    const userBrowserLanguage = this.getUserBrowserLanguage();
+
+    const isLanguageCodeInAvailablelLanguageFile = !!localization &&
+      this.isLanguageCodeInAvailablelLanguageFile(
+      localization.availableLanguageFile, userBrowserLanguage
+    );
+
+    if (!userBrowserLanguage || !localization || !isLanguageCodeInAvailablelLanguageFile) {
+      return this.getDefaultLanguage(localization);
+    }
+
+    return userBrowserLanguage;
   },
 
   /**
@@ -714,7 +710,7 @@ var Utils = {
     if ( !(availableLanguageList && Array.isArray(availableLanguageList) && languageCode) ) {
       return false;
     }
-    return !!availableLanguageList.find(languageObj => languageObj.language === languageCode);
+    return availableLanguageList.some(languageObj => languageObj.language === languageCode);
   },
 
   /**

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -527,47 +527,89 @@ describe('Utils', function() {
     expect(isIE10).toBeFalsy();
   });
 
-  it('tests getLanguageToUse', function() {
-    var skinConfig = {
+  describe('tests getDefaultLanguage', function() {
+    it('should return an empty string if param "localization" is wrong type', function(){
+      const emptyToParam = Utils.getDefaultLanguage();
+      expect(emptyToParam).toBe('');
+      const nullToParam = Utils.getDefaultLanguage(null);
+      expect(nullToParam).toBe('');
+      const arrayToParam = Utils.getDefaultLanguage([1, 2, 3]);
+      expect(arrayToParam).toBe('');
+    });
+
+    it('should return an empty string if param "localization" does not have field "defaultLanguage',
+      function() {
+        const defaultLanguage = Utils.getDefaultLanguage({'test': 1});
+        expect(defaultLanguage).toBe('');
+      }
+    );
+
+    it('should return "defaultLanguage" from "localization" object', function(){
+      const defaultLanguage = Utils.getDefaultLanguage({'defaultLanguage': 'en'});
+      expect(defaultLanguage).toBe('en');
+    });
+  });
+
+  describe('tests getLanguageToUse', function() {
+    let skinConfig = {
       localization: {
         defaultLanguage: 'zh'
       }
     };
-    var skinConfig2 = {
-      localization: {
-        defaultLanguage: '',
-        availableLanguageFile: [
-          {
-            'language': 'en',
-            'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/en.json',
-            'androidResource': 'skin-config/en.json',
-            'iosResource': 'en'
-          },
-          {
-            'language': 'es',
-            'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/es.json',
-            'androidResource': 'skin-config/es.json',
-            'iosResource': 'es'
-          },
-          {
-            'language': 'zh',
-            'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/zh.json',
-            'androidResource': 'skin-config/zh.json',
-            'iosResource': 'zh'
-          }
-        ]
-      }
-    };
-    var getLanguageToUse = Utils.getLanguageToUse(skinConfig);
-    expect(getLanguageToUse).toEqual('zh');
-    //window.navigator.languages defaults to ['en-US', 'en']
-    getLanguageToUse = Utils.getLanguageToUse(skinConfig2);
-    expect(getLanguageToUse).toEqual('en');
-    //test window.navigator.browserLanguage
-    OO_setWindowNavigatorProperty('languages', null);
-    window.navigator.browserLanguage = 'es-US';
-    getLanguageToUse = Utils.getLanguageToUse(skinConfig2);
-    expect(getLanguageToUse).toEqual('es');
+    beforeEach(function() {});
+
+    afterEach(function() {
+      skinConfig = {
+        localization: {
+          defaultLanguage: 'zh'
+        }
+      };
+    });
+
+    it('should return an empty string if there is no skinConfig', function() {
+      const getLanguageToUse = Utils.getLanguageToUse();
+      expect(getLanguageToUse).toBe('');
+    });
+    it('should return an empty string if skinConfig does not have "defaultLanguage" and ' +
+      'browser language is unknown' , function() {
+      skinConfig = {};
+      const getLanguageToUse = Utils.getLanguageToUse(skinConfig);
+      expect(getLanguageToUse).toBe('');
+    });
+    it('should return zh if "defaultLanguage" === "zh" and browser language is unknown', function() {
+      const getLanguageToUse = Utils.getLanguageToUse(skinConfig);
+      expect(getLanguageToUse).toBe('zh');
+    });
+    it('should return es if browser language is "es" and this vale is in "availableLanguageFile"', function() {
+      skinConfig = {
+        localization: {
+          defaultLanguage: 'en',
+          availableLanguageFile: [
+            {
+              'language': 'en',
+              'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/en.json',
+              'androidResource': 'skin-config/en.json',
+              'iosResource': 'en'
+            },
+            {
+              'language': 'es',
+              'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/es.json',
+              'androidResource': 'skin-config/es.json',
+              'iosResource': 'es'
+            },
+            {
+              'language': 'zh',
+              'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/zh.json',
+              'androidResource': 'skin-config/zh.json',
+              'iosResource': 'zh'
+            }
+          ]
+        }
+      };
+      OO_setWindowNavigatorProperty('language', 'es-US');
+      const getLanguageToUse = Utils.getLanguageToUse(skinConfig);
+      expect(getLanguageToUse).toBe('es');
+    });
   });
 
   it('tests getLocalizedString', function() {

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -1372,17 +1372,19 @@ describe('Controller', function() {
     });
 
     afterEach(function() {
-      spyPublish.restore()
+      spyPublish.restore();
     });
 
     it('test that the chosen ui language is sent on the message bus', function() {
+      OO_setWindowNavigatorProperty('language', undefined);
       controller.loadConfigData('customerUi', {"localization":{"defaultLanguage":"es"}}, {}, {}, {});
       expect(spyPublish.withArgs(OO.EVENTS.SKIN_UI_LANGUAGE, sinon.match("es")).calledOnce).toBe(true);
     });
 
     it('test that language defaults to english if no defaultLanguage is specified', function() {
+      OO_setWindowNavigatorProperty('language', 'en');
       controller.loadConfigData('customerUi', {"localization":{"defaultLanguage":""}}, {}, {}, {});
-      expect(spyPublish.withArgs(OO.EVENTS.SKIN_UI_LANGUAGE, sinon.match("en")).calledOnce).toBe(true);
+      expect(spyPublish.withArgs(OO.EVENTS.SKIN_UI_LANGUAGE, sinon.match('en')).calledOnce).toBe(true);
     });
   });
 


### PR DESCRIPTION
Now a default language is the most prioritise language.

New language selection logic for UI:
- if we can get user language, and this language is in the list of available languages, then we use this language
- if we can get user language, but this language is not in the list of available languages, then we use the default language
- if it is impossible to determine the user's language, then use the default language

Unit tests passed.
\
\
\
Extra information:
At the beginning of the player starts, the "getLanguageToUse" function is called twice: when the function "onPlayerCreated"  is called (here we get the value from skin.json) and when function "onSkinMetaDataFetched" is called (here the value from skin.json is overridden by the value from page-level params).