### PR TITLE
[PLAYER-5025] - Issue when exiting the full screen mode once the video finishes playback

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -2059,7 +2059,7 @@ module.exports = function(OO, _, $, W) {
       // [PLAYER-212]
       // We can't show UI such as the "Up Next" countdown on fullscreen iOS. If a countdown
       // is configured, we wait until the user exits fullscreen and then we display it.
-      if (showUpNext && this.state.playerState === CONSTANTS.STATE.END) {
+      if (showUpNext && this.state.playerState === CONSTANTS.STATE.END && this.state.discoveryData) {
         this.state.forceCountDownTimerOnEndScreen = true;
         this.sendDiscoveryDisplayEventRelatedVideos('endScreen');
         this.state.discoverySource = CONSTANTS.SCREEN.END_SCREEN;


### PR DESCRIPTION
Adding null check for discoveryData to prevent errors.