### PR TITLE
[PLAYER-5026][WEB][Chromecast] Reload the page when casting

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1059,7 +1059,7 @@ module.exports = function(OO, _, $, W) {
     },
 
     onPlayed: function() {
-      var duration = this.state.mainVideoDuration;
+      var duration = this.state.mainVideoDuration || this.state.contentTree.duration / 1000;
       this.state.duration = duration;
       this.state.playerState = CONSTANTS.STATE.END;
 


### PR DESCRIPTION
[Jira Link](https://jira.corp.ooyala.com/browse/PLAYER-5026)

Corresponding PRs for [Receiver](https://github.com/ooyala/chromecast-sample-receiver/pull/68) and [Sender](https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/618/overview)

This issue manifests itself when playback is done and I want to reload the page (when casting)

Steps:
* Open the debug link: https://tinyurl.com/yc2my2c8
* Connect to chromecast
* Video plays on receiver
* Refresh the page when playback's ended
* Player shows the start screen with play button but on clicking the play button it buffers indefinitely