### PR TITLE
[fix/PBW-7648] The default image appears on Mobile webview

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1463,7 +1463,7 @@ module.exports = function(OO, _, $, W) {
         this.state.adEndTime = this.state.adStartTime + this.state.adVideoDuration;
         this.skin.state.currentPlayhead = 0;
         this.removeBlur();
-        this.renderSkin();
+        if (adItem.ssai) this.renderSkin();
       }
     },
 

--- a/js/controller.js
+++ b/js/controller.js
@@ -1463,7 +1463,9 @@ module.exports = function(OO, _, $, W) {
         this.state.adEndTime = this.state.adStartTime + this.state.adVideoDuration;
         this.skin.state.currentPlayhead = 0;
         this.removeBlur();
-        if (adItem.ssai) this.renderSkin();
+        if (adItem.ssai) {
+          this.renderSkin();
+        }
       }
     },
 


### PR DESCRIPTION
Removed renderSkin() from onWillPlaySingleAD because of Webview default image appearing.
This was fixed previously by removing this renderSkin(), but it led to ssai issues.

https://jira.corp.ooyala.com/browse/PBW-7648