### PR TITLE
[feature/PLAYER-4606] default UI language: Use the browser settings over skin.json with page-level param

### DIFF
--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -645,10 +645,10 @@ var Utils = {
     let userBrowserLanguage;
     let isLanguageCodeInAvailablelLanguageFile = false;
 
-    const isUseUserBrowserLanguage = playerParam && playerParam['useUserBrowserLanguage'];
+    const isUseBrowserLanguage = playerParam && playerParam['useBrowserLanguage'];
 
     // if useUserBrowserLanguage is set to true, use language from user browser settings
-    if (isUseUserBrowserLanguage) {
+    if (isUseBrowserLanguage) {
       userBrowserLanguage = this.getUserBrowserLanguage();
       isLanguageCodeInAvailablelLanguageFile = !!localization &&
         this.isLanguageCodeInAvailablelLanguageFile(

--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -632,43 +632,96 @@ var Utils = {
    *
    * @function getLanguageToUse
    * @param {Object} skinConfig - The skin configuration file to read languages from
-   * @returns {String} The ISO code of the language to use
+   * @param {Object} playerParam - Page-level params
+   * @returns {String} The ISO 639-1 code of the language to use or an empty string
    */
-  getLanguageToUse: function(skinConfig) {
-    var localization = skinConfig.localization;
-    var language, availableLanguages;
-
-    // set lang to default lang in skin config
-    language = localization.defaultLanguage;
-
-    // if no default lang in skin config check browser lang settings
-    if (!language) {
-      if (window.navigator.languages) {
-        // A String, representing the language version of the browser.
-        // Examples of valid language codes are: "en", "en-US", "de", "fr", etc.
-        language = window.navigator.languages[0];
-      } else {
-        // window.navigator.browserLanguage: current operating system language
-        // window.navigator.userLanguage: operating system's natural language setting
-        // window.navigator.language: the preferred language of the user, usually the language of the browser UI
-        language =
-          window.navigator.browserLanguage || window.navigator.userLanguage || window.navigator.language;
-      }
-
-      // remove lang sub-code
-      var primaryLanguage = language.substr(0, 2);
-
-      // check available lang file for browser lang
-      for (var i = 0; i < localization.availableLanguageFile.length; i++) {
-        availableLanguages = localization.availableLanguageFile[i];
-        // if lang file available set lang to browser primary lang
-        if (primaryLanguage === availableLanguages.language) {
-          language = primaryLanguage;
-        }
-      }
+  getLanguageToUse: function(skinConfig, playerParam) {
+    if (!skinConfig) {
+      return '';
     }
 
-    return language;
+    const localization = skinConfig.localization;
+
+    let userBrowserLanguage;
+    let isLanguageCodeInAvailablelLanguageFile = false;
+
+    const isUseUserBrowserLanguage = playerParam && playerParam['useUserBrowserLanguage'];
+
+    // if useUserBrowserLanguage is set to true, use language from user browser settings
+    if (isUseUserBrowserLanguage) {
+      userBrowserLanguage = this.getUserBrowserLanguage();
+      isLanguageCodeInAvailablelLanguageFile = !!localization &&
+        this.isLanguageCodeInAvailablelLanguageFile(
+          localization.availableLanguageFile, userBrowserLanguage
+        );
+    }
+
+    if (!userBrowserLanguage || !localization || !isLanguageCodeInAvailablelLanguageFile) {
+      // if useUserBrowserLanguage is not set to true or
+      // useUserBrowserLanguage is set to true but browser language is not checkable or
+      // there is no browser language in availableLanguageFile
+      return this.getDefaultLanguage(localization);
+    }
+    return userBrowserLanguage;
+  },
+
+  /**
+   *
+   * @param {Object} localization - location configuration object
+   * @param {String} localization.defaultLanguage - value for default language
+   * @returns {String} defaultLanguage - language code from file "skin.json" (
+   * before executing function "onSkinMetaDataFetched") or language code that was set
+   * in the page-level parameters (after executing function "onSkinMetaDataFetched")
+   */
+  getDefaultLanguage: function(localization) {
+    let defaultLanguage = '';
+    if ( (typeof localization === "object") && (localization !== null) ) {
+      defaultLanguage = localization.defaultLanguage ?
+        localization.defaultLanguage
+      : defaultLanguage;
+    }
+    return defaultLanguage;
+  },
+
+  /**
+   *
+   * @returns {String} two-digit value of an user's system language or an empty string
+   */
+  getUserBrowserLanguage: function() {
+    // Examples of valid language codes are: "en", "en-US", "de", "fr", etc.
+    let navigator = window.navigator;
+    let language;
+    if (navigator) {
+      language = (
+        navigator.language ||
+        // "language" property returns the language of the browser application in
+        // Firefox, Opera, Google Chrome and Safari
+        navigator.userLanguage ||
+        // "userLanguage" property returns the current Regional and Language settings
+        // of the operating system in
+        // Internet Explorer and the language of the browser application in Opera
+        navigator.systemLanguage
+        // "systemLanguage" property returns the language edition of the operating system in
+        // Internet Explorer
+      )
+    }
+    return language ? language.substr(0, 2).toLowerCase() : ''; // remove lang sub-code
+  },
+
+  /**
+   *
+   * @param {Array} availableLanguageList - array of objects of language code values
+   * with the key "language"
+   * @param languageCode - two-digit value of the language
+   * @returns {Boolean} "true" if the corresponding language code "languageCode" is
+   * in the array of available languages "availableLanguageList",
+   * otherwise "false"
+   */
+  isLanguageCodeInAvailablelLanguageFile: function(availableLanguageList, languageCode) {
+    if ( !(availableLanguageList && Array.isArray(availableLanguageList) && languageCode) ) {
+      return false;
+    }
+    return availableLanguageList.some(languageObj => languageObj.language === languageCode);
   },
 
   /**

--- a/js/components/utils.js
+++ b/js/components/utils.js
@@ -674,13 +674,8 @@ var Utils = {
    * in the page-level parameters (after executing function "onSkinMetaDataFetched")
    */
   getDefaultLanguage: function(localization) {
-    let defaultLanguage = '';
-    if ( (typeof localization === "object") && (localization !== null) ) {
-      defaultLanguage = localization.defaultLanguage ?
-        localization.defaultLanguage
-      : defaultLanguage;
-    }
-    return defaultLanguage;
+    const defaultLanguage = !!localization && localization.defaultLanguage;
+    return defaultLanguage || '';
   },
 
   /**

--- a/js/controller.js
+++ b/js/controller.js
@@ -1706,7 +1706,8 @@ module.exports = function(OO, _, $, W) {
         this.state.config.discoveryScreen.countDownTime
       );
 
-      var uiLanguage = Utils.getLanguageToUse(this.state.config);
+      const { config, playerParam } = this.state;
+      const uiLanguage = Utils.getLanguageToUse(config, playerParam);
       this.mb.publish(OO.EVENTS.SKIN_UI_LANGUAGE, uiLanguage);
 
       this.state.audioOnly = params.playerType === OO.CONSTANTS.PLAYER_TYPE.AUDIO;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -552,7 +552,7 @@
     },
     "@babel/plugin-transform-modules-commonjs": {
       "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
+      "resolved": "https://nexus.ooflex.net/repository/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.1.0.tgz",
       "integrity": "sha512-wtNwtMjn1XGwM0AXPspQgvmE6msSJP15CX2RVfpTSTNPLhKhaOjaIfBaVfj4iUZ/VrFSodcFedwtPg/NxwQlPA==",
       "dev": true,
       "requires": {
@@ -1115,7 +1115,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
       "dev": true
     },
     "accepts": {
@@ -1400,7 +1400,7 @@
     "are-we-there-yet": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "integrity": "sha1-SzXClE8GKov82mZBB2A1D+nd/CE=",
       "dev": true,
       "requires": {
         "delegates": "^1.0.0",
@@ -6333,7 +6333,7 @@
     "gaze": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
-      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
+      "integrity": "sha1-xEFzPhO5J6yMD/C0w7Az8ogSkko=",
       "dev": true,
       "requires": {
         "globule": "^1.0.0"
@@ -6620,7 +6620,7 @@
     "globule": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
-      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
+      "integrity": "sha1-Xf+xsZHyLSB5epNptJ6rTpg5aW0=",
       "dev": true,
       "requires": {
         "glob": "~7.1.1",
@@ -6737,7 +6737,7 @@
       "dependencies": {
         "ansi-colors": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-2.0.5.tgz",
+          "resolved": "https://nexus.ooflex.net/repository/npm/ansi-colors/-/ansi-colors-2.0.5.tgz",
           "integrity": "sha512-yAdfUZ+c2wetVNIFsNRn44THW+Lty6S5TwMpUfLA/UaGhiXbBv/F8E60/1hMLd0cnF/CDoWH8vzVaI5bAcHCjw==",
           "dev": true
         }
@@ -9549,7 +9549,7 @@
     "lodash.mergewith": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
-      "integrity": "sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==",
+      "integrity": "sha1-Y5BX5ybDr72z59QnQcqo1uQzWSc=",
       "dev": true
     },
     "lodash.restparam": {
@@ -10613,7 +10613,7 @@
     "npmlog": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "integrity": "sha1-CKfyqL9zRgR3mp76StXMcXq7lUs=",
       "dev": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
@@ -10959,7 +10959,7 @@
     "osenv": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
       "dev": true,
       "requires": {
         "os-homedir": "^1.0.0",
@@ -17258,7 +17258,7 @@
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "integrity": "sha1-rgdOa9wMFKQx6ATmJFScYzsABFc=",
       "dev": true,
       "requires": {
         "string-width": "^1.0.2 || 2"

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -582,7 +582,7 @@ describe('Utils', function() {
     });
 
     it('should return en if ' +
-      'page-level param "useUserBrowserLanguage" is not set to true but ' +
+      'page-level param "useBrowserLanguage" is not set to true but ' +
       'browser language is "es" and' +
       'this language is in "availableLanguageFile"',
       () => {
@@ -618,7 +618,7 @@ describe('Utils', function() {
     );
 
     it('should return es if ' +
-      'page-level param "useUserBrowserLanguage" is true and ' +
+      'page-level param "useBrowserLanguage" is true and ' +
       'browser language is "es" and' +
       'this language is in "availableLanguageFile"',
       () => {
@@ -648,14 +648,14 @@ describe('Utils', function() {
           }
         };
         OO_setWindowNavigatorProperty('language', 'es-US');
-        const playerParam = {useUserBrowserLanguage: true};
+        const playerParam = {useBrowserLanguage: true};
         const getLanguageToUse = Utils.getLanguageToUse(skinConfig, playerParam);
         expect(getLanguageToUse).toBe('es');
       }
     );
 
     it('should return en (by default) if ' +
-      'page-level param "useUserBrowserLanguage" is true and ' +
+      'page-level param "useBrowserLanguage" is true and ' +
       'browser language is "es" but' +
       'this language is not in "availableLanguageFile"',
       () => {
@@ -679,7 +679,7 @@ describe('Utils', function() {
           }
         };
         OO_setWindowNavigatorProperty('language', 'es-US');
-        const playerParam = {useUserBrowserLanguage: true};
+        const playerParam = {useBrowserLanguage: true};
         const getLanguageToUse = Utils.getLanguageToUse(skinConfig, playerParam);
         expect(getLanguageToUse).toBe('en');
       }

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -527,47 +527,164 @@ describe('Utils', function() {
     expect(isIE10).toBeFalsy();
   });
 
-  it('tests getLanguageToUse', function() {
-    var skinConfig = {
+  describe('tests getDefaultLanguage', function() {
+    it('should return an empty string if param "localization" is wrong type', function(){
+      const emptyToParam = Utils.getDefaultLanguage();
+      expect(emptyToParam).toBe('');
+      const nullToParam = Utils.getDefaultLanguage(null);
+      expect(nullToParam).toBe('');
+      const arrayToParam = Utils.getDefaultLanguage([1, 2, 3]);
+      expect(arrayToParam).toBe('');
+    });
+
+    it('should return an empty string if param "localization" does not have field "defaultLanguage',
+      function() {
+        const defaultLanguage = Utils.getDefaultLanguage({'test': 1});
+        expect(defaultLanguage).toBe('');
+      }
+    );
+
+    it('should return "defaultLanguage" from "localization" object', function(){
+      const defaultLanguage = Utils.getDefaultLanguage({'defaultLanguage': 'en'});
+      expect(defaultLanguage).toBe('en');
+    });
+  });
+
+  describe('tests getLanguageToUse', function() {
+    let skinConfig = {
       localization: {
         defaultLanguage: 'zh'
       }
     };
-    var skinConfig2 = {
-      localization: {
-        defaultLanguage: '',
-        availableLanguageFile: [
-          {
-            'language': 'en',
-            'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/en.json',
-            'androidResource': 'skin-config/en.json',
-            'iosResource': 'en'
-          },
-          {
-            'language': 'es',
-            'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/es.json',
-            'androidResource': 'skin-config/es.json',
-            'iosResource': 'es'
-          },
-          {
-            'language': 'zh',
-            'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/zh.json',
-            'androidResource': 'skin-config/zh.json',
-            'iosResource': 'zh'
+    beforeEach(function() {});
+
+    afterEach(function() {
+      skinConfig = {
+        localization: {
+          defaultLanguage: 'zh'
+        }
+      };
+    });
+
+    it('should return an empty string if there is no skinConfig', function() {
+      const getLanguageToUse = Utils.getLanguageToUse();
+      expect(getLanguageToUse).toBe('');
+    });
+    it('should return an empty string if skinConfig does not have "defaultLanguage" and ' +
+      'browser language is unknown' , function() {
+      skinConfig = {};
+      const getLanguageToUse = Utils.getLanguageToUse(skinConfig);
+      expect(getLanguageToUse).toBe('');
+    });
+    it('should return zh if "defaultLanguage" === "zh" and browser language is unknown', function() {
+      const getLanguageToUse = Utils.getLanguageToUse(skinConfig);
+      expect(getLanguageToUse).toBe('zh');
+    });
+
+    it('should return en if ' +
+      'page-level param "useUserBrowserLanguage" is not set to true but ' +
+      'browser language is "es" and' +
+      'this language is in "availableLanguageFile"',
+      () => {
+        skinConfig = {
+          localization: {
+            defaultLanguage: 'en',
+            availableLanguageFile: [
+              {
+                'language': 'en',
+                'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/en.json',
+                'androidResource': 'skin-config/en.json',
+                'iosResource': 'en'
+              },
+              {
+                'language': 'es',
+                'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/es.json',
+                'androidResource': 'skin-config/es.json',
+                'iosResource': 'es'
+              },
+              {
+                'language': 'zh',
+                'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/zh.json',
+                'androidResource': 'skin-config/zh.json',
+                'iosResource': 'zh'
+              }
+            ]
           }
-        ]
+        };
+        OO_setWindowNavigatorProperty('language', 'es-US');
+        const getLanguageToUse = Utils.getLanguageToUse(skinConfig, null);
+        expect(getLanguageToUse).toBe('en');
       }
-    };
-    var getLanguageToUse = Utils.getLanguageToUse(skinConfig);
-    expect(getLanguageToUse).toEqual('zh');
-    //window.navigator.languages defaults to ['en-US', 'en']
-    getLanguageToUse = Utils.getLanguageToUse(skinConfig2);
-    expect(getLanguageToUse).toEqual('en');
-    //test window.navigator.browserLanguage
-    OO_setWindowNavigatorProperty('languages', null);
-    window.navigator.browserLanguage = 'es-US';
-    getLanguageToUse = Utils.getLanguageToUse(skinConfig2);
-    expect(getLanguageToUse).toEqual('es');
+    );
+
+    it('should return es if ' +
+      'page-level param "useUserBrowserLanguage" is true and ' +
+      'browser language is "es" and' +
+      'this language is in "availableLanguageFile"',
+      () => {
+        skinConfig = {
+          localization: {
+            defaultLanguage: 'zh',
+            availableLanguageFile: [
+              {
+                'language': 'en',
+                'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/en.json',
+                'androidResource': 'skin-config/en.json',
+                'iosResource': 'en'
+              },
+              {
+                'language': 'es',
+                'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/es.json',
+                'androidResource': 'skin-config/es.json',
+                'iosResource': 'es'
+              },
+              {
+                'language': 'zh',
+                'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/zh.json',
+                'androidResource': 'skin-config/zh.json',
+                'iosResource': 'zh'
+              }
+            ]
+          }
+        };
+        OO_setWindowNavigatorProperty('language', 'es-US');
+        const playerParam = {useUserBrowserLanguage: true};
+        const getLanguageToUse = Utils.getLanguageToUse(skinConfig, playerParam);
+        expect(getLanguageToUse).toBe('es');
+      }
+    );
+
+    it('should return en (by default) if ' +
+      'page-level param "useUserBrowserLanguage" is true and ' +
+      'browser language is "es" but' +
+      'this language is not in "availableLanguageFile"',
+      () => {
+        skinConfig = {
+          localization: {
+            defaultLanguage: 'en',
+            availableLanguageFile: [
+              {
+                'language': 'en',
+                'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/en.json',
+                'androidResource': 'skin-config/en.json',
+                'iosResource': 'en'
+              },
+              {
+                'language': 'zh',
+                'languageFile': '//player.ooyala.com/static/v4/candidate/latest/skin-plugin/zh.json',
+                'androidResource': 'skin-config/zh.json',
+                'iosResource': 'zh'
+              }
+            ]
+          }
+        };
+        OO_setWindowNavigatorProperty('language', 'es-US');
+        const playerParam = {useUserBrowserLanguage: true};
+        const getLanguageToUse = Utils.getLanguageToUse(skinConfig, playerParam);
+        expect(getLanguageToUse).toBe('en');
+      }
+    );
+
   });
 
   it('tests getLocalizedString', function() {

--- a/tests/components/utils-test.js
+++ b/tests/components/utils-test.js
@@ -551,22 +551,14 @@ describe('Utils', function() {
   });
 
   describe('tests getLanguageToUse', function() {
-    let skinConfig = {
-      localization: {
-        defaultLanguage: 'zh'
-      }
-    };
-    beforeEach(function() {});
+    let skinConfig;
 
-    afterEach(function() {
+    it('should return an empty string if there is no skinConfig', function() {
       skinConfig = {
         localization: {
           defaultLanguage: 'zh'
         }
       };
-    });
-
-    it('should return an empty string if there is no skinConfig', function() {
       const getLanguageToUse = Utils.getLanguageToUse();
       expect(getLanguageToUse).toBe('');
     });
@@ -577,6 +569,11 @@ describe('Utils', function() {
       expect(getLanguageToUse).toBe('');
     });
     it('should return zh if "defaultLanguage" === "zh" and browser language is unknown', function() {
+      skinConfig = {
+        localization: {
+          defaultLanguage: 'zh'
+        }
+      };
       const getLanguageToUse = Utils.getLanguageToUse(skinConfig);
       expect(getLanguageToUse).toBe('zh');
     });

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -1383,13 +1383,16 @@ describe('Controller', function() {
     });
 
     it('test that the chosen ui language is sent on the message bus', function() {
+      OO_setWindowNavigatorProperty('language', undefined);
       controller.loadConfigData('customerUi', {"localization":{"defaultLanguage":"es"}}, {}, {}, {});
       expect(spyPublish.withArgs(OO.EVENTS.SKIN_UI_LANGUAGE, sinon.match("es")).calledOnce).toBe(true);
     });
 
     it('test that language defaults to english if no defaultLanguage is specified', function() {
+      OO_setWindowNavigatorProperty('language', 'en');
+      controller.state.playerParam = {...controller.state.playerParam, "useUserBrowserLanguage": true};
       controller.loadConfigData('customerUi', {"localization":{"defaultLanguage":""}}, {}, {}, {});
-      expect(spyPublish.withArgs(OO.EVENTS.SKIN_UI_LANGUAGE, sinon.match("en")).calledOnce).toBe(true);
+      expect(spyPublish.withArgs(OO.EVENTS.SKIN_UI_LANGUAGE, sinon.match('en')).calledOnce).toBe(true);
     });
   });
 

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -1390,7 +1390,7 @@ describe('Controller', function() {
 
     it('test that language defaults to english if no defaultLanguage is specified', function() {
       OO_setWindowNavigatorProperty('language', 'en');
-      controller.state.playerParam = {...controller.state.playerParam, "useUserBrowserLanguage": true};
+      controller.state.playerParam = {...controller.state.playerParam, "useBrowserLanguage": true};
       controller.loadConfigData('customerUi', {"localization":{"defaultLanguage":""}}, {}, {}, {});
       expect(spyPublish.withArgs(OO.EVENTS.SKIN_UI_LANGUAGE, sinon.match('en')).calledOnce).toBe(true);
     });


### PR DESCRIPTION
New logic to choose default language

1. if "useBrowserLanguage" is set to true
try to check browser language,
if it is checkable, use it as a default language,
if it is not checkable, use defaultLanguage from inline props on page-level params,
if it is not checkable and defaultLanguage on page-level params is not set, use default language

2.  if "useBrowserLanguage" is not set to true
use defaultLanguage from inline props on page-level params,
defaultLanguage on page-level params is not set, use default language

Unit tests passed