### PR TITLE
fix/PLAYER-4978 discovery plugin optionality is now respected

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -384,7 +384,7 @@ module.exports = function(OO, _, $, W) {
     },
 
     externalPluginSubscription: function() {
-      if (OO.EVENTS.DISCOVERY_API) {
+      if (OO.EVENTS.DISCOVERY_API && OO.EVENTS.DISCOVERY_API.RELATED_VIDEOS_FETCHED) {
         this.mb.subscribe(
           OO.EVENTS.DISCOVERY_API.RELATED_VIDEOS_FETCHED,
           'customerUi',


### PR DESCRIPTION
Some of the discovery events are `undefined` if discovery plugin is not loaded. It is optional. Therefore subscription should check additionally if the event exists in the OO.EVENTS.DISCOVERY_API namespace.