### PR TITLE
[bugfix/PLAYER-5111] Player controls are not coming up with Audio only player

### DIFF
--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -323,13 +323,26 @@ var ControlBar = createReactClass({
   },
 
   /**
-  * @description Retrieves configuration from server to be applied to audio skin
-  **/
+   * @description Retrieves configuration from server to be applied to audio skin
+   *  @returns {Array} list of icons to show on a screen
+  */
   getAudioControlsConfig: function() {
     //We receive location param in desktopContent, instead of audioOnly.
     //This is necessary to display or not the button, depending on Backlot settings.
-    var defaultConfig = JSON.parse(JSON.stringify(this.props.skinConfig.buttons.audioOnly));
-    this.props.skinConfig.buttons.desktopContent.forEach(item => {
+    if (!(this.props.skinConfig &&
+      this.props.skinConfig.buttons &&
+      this.props.skinConfig.buttons.audioOnly &&
+      this.props.skinConfig.buttons.audioOnly.desktop &&
+      Array.isArray(this.props.skinConfig.buttons.audioOnly.desktop))
+    ) {
+      return [];
+    }
+
+    const audioOnlyButtonsList = this.props.skinConfig.buttons.audioOnly.desktop;
+    const desktopContent = this.props.skinConfig.buttons.desktopContent;
+    const defaultConfig = JSON.parse(JSON.stringify(audioOnlyButtonsList));
+
+    desktopContent.forEach(item => {
       if (item.location !== 'none') {
         return;
       }
@@ -338,7 +351,7 @@ var ControlBar = createReactClass({
       ).forEach(
         field => field.location = 'none'
       );
-      });
+    });
     return defaultConfig;
   },
 

--- a/tests/components/controlBar-test.js
+++ b/tests/components/controlBar-test.js
@@ -1250,13 +1250,31 @@ describe('ControlBar', function() {
       expect(wrapper.find('.oo-skip-controls').length).toBe(1);
     });
 
-    it('tests rendering audio only buttons', () => {
-      baseMockProps.skinConfig.buttons.audioOnly = [
-        {"name":"skipControls", "location":"controlBar", "whenDoesNotFit":"keep", "minWidth":200 }
-      ];
-      baseMockProps.audioOnly = true;
-      var wrapper = Enzyme.mount(getControlBar());
-      expect(wrapper.find('.oo-skip-controls').length).toBe(1);
+    describe('AudioOnly', () => {
+      let audioOnlyConf;
+      beforeEach(() => {
+        audioOnlyConf = baseMockProps.skinConfig.buttons.audioOnly;
+      });
+      afterEach(() => {
+        baseMockProps.skinConfig.buttons.audioOnly = audioOnlyConf;
+      });
+      it('tests rendering audio only buttons', () => {
+        baseMockProps.skinConfig.buttons.audioOnly.desktop = [
+          {"name":"skipControls", "location":"controlBar", "whenDoesNotFit":"keep", "minWidth":200 }
+        ];
+        baseMockProps.audioOnly = true;
+        const wrapper = Enzyme.mount(getControlBar());
+        expect(wrapper.find('.oo-skip-controls').length).toBe(1);
+      });
+
+      it('function getAudioControlsConfig should not get crash if no desktop icons array', () => {
+        baseMockProps.skinConfig.buttons.audioOnly = null;
+        baseMockProps.audioOnly = true;
+        const wrapper = Enzyme.mount(getControlBar());
+        const composedComponent = wrapper.instance().composedComponentRef.current;
+        const audioOnlyIconsList = composedComponent.getAudioControlsConfig();
+        expect(audioOnlyIconsList).toEqual([]);
+      });
     });
 
     it('tests row format for audio only', () => {


### PR DESCRIPTION
Icons for audioOnly on controlBar was moved in skin-config to outer object. That was the reason of the bug.

Key "desktop" for the icons was added, 
also an error (when method "filter" was called on undefined (this.props.skinConfig.buttons.audioOnly)) was fixed.

Unit tests passed.

[Connected PR](https://github.com/ooyala/skin-config/pull/231)