### PR TITLE
[fix/PLAYER-5160] v4] Double loading spinner on ads

### DIFF
--- a/js/components/adPanel.js
+++ b/js/components/adPanel.js
@@ -9,7 +9,6 @@
  */
 var React = require('react'),
     CONSTANTS = require('../constants/constants'),
-    Spinner = require('./spinner'),
     ClassNames = require('classnames'),
     Utils = require('./utils'),
     Icon = require('../components/icon');
@@ -170,14 +169,9 @@ var AdPanel = createReactClass({
   },
 
   render: function() {
-    var spinner = null;
-    if (this.props.controller.state.buffering === true) {
-      spinner = <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url} />;
-    }
     var adTopBarItems = this.populateAdTopBar();
     return (
       <div className="oo-ad-screen-panel">
-        {spinner}
         <div className="oo-ad-screen-panel-click-layer" />
         <div
           className="oo-ad-top-bar"


### PR DESCRIPTION
Recently Ksenia added the Spinner to the AdScreen so we should remove the Spinner from the AdPanel which is used inside the AdScreen with condition of 'showAdMarquee'.

https://jira.corp.ooyala.com/browse/PLAYER-5160