### PR TITLE
Added AriaLabel param for airPlay

### DIFF
--- a/js/components/controlBar.js
+++ b/js/components/controlBar.js
@@ -619,6 +619,7 @@ var ControlBar = createReactClass({
           key={CONSTANTS.CONTROL_BAR_KEYS.AIRPLAY}
           className="oo-airplay"
           focusId={CONSTANTS.CONTROL_BAR_KEYS.AIRPLAY}
+          ariaLabel={CONSTANTS.ARIA_LABELS.AIRPLAY}
           icon={this.props.controller.state.airPlayStatusIcon}
           tooltip={CONSTANTS.SKIN_TEXT.AIRPLAY}
           onClick={this.handleAirPlayClick}>

--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -186,7 +186,8 @@ var CONSTANTS = {
     PLAYBACK_SPEED: MACROS.RATE + 'x Playback Speed',
     PLAYBACK_SPEED_OPTION: 'Speed',
     NORMAL_SPEED: 'Normal Speed',
-    CHROMECAST: 'Chromecast'
+    CHROMECAST: 'Chromecast',
+    AIRPLAY: 'Airplay'
   },
 
   CONTROL_BAR_KEYS: {


### PR DESCRIPTION
ariaLabel is required param so this fix is removing a warning of proptypes