### PR TITLE
[fix/PLAYER-5095] Trigger targetPicker only after 'playing' event

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -492,22 +492,21 @@ module.exports = function(OO, _, $, W) {
       this.renderSkin({cast: {connected:false, device: ""}});
     },
 
+    showAirplayPicker: function() {
+      this.showControlBar();
+      this.state.mainVideoElement.webkitShowPlaybackTargetPicker();
+      this.state.mainVideoElement.removeEventListener('playing', this.showAirplayPickerBound);
+    },
+
+    showAirplayPickerBound: undefined,
+
     airPlayListener: function(event) {
       this.state.isAirPlayAvailable = event.availability === 'available';
       this.renderSkin();
     },
 
-    toggleAirPlayIcon: function(event) {
+    toggleAirPlayIcon: function() {
       if (!this.state.airPlayStatusIcon) {
-        const airPlayState = window.sessionStorage.getItem('airPlayState');
-        if (airPlayState === CONSTANTS.AIRPLAY_STATE.CONNECTED) {
-          const onVideoPlaying = () => {
-            this.showControlBar();
-            this.state.mainVideoElement.webkitShowPlaybackTargetPicker();
-            this.state.mainVideoElement.removeEventListener('playing', onVideoPlaying);
-          };
-          this.state.mainVideoElement.addEventListener('playing', onVideoPlaying);
-        }
         this.state.airPlayStatusIcon = CONSTANTS.AIRPLAY_STATE.DISCONNECTED;
         this.renderSkin();
         return;
@@ -604,6 +603,12 @@ module.exports = function(OO, _, $, W) {
           //This event fires when a media element starts or stops AirPlay playback
           videoElement.addEventListener('webkitcurrentplaybacktargetiswirelesschanged',
             _.bind(this.toggleAirPlayIcon, this));
+
+          const airPlayState = window.sessionStorage.getItem('airPlayState');
+          if (airPlayState === CONSTANTS.AIRPLAY_STATE.CONNECTED) {
+            this.showAirplayPickerBound = this.showAirplayPicker.bind(this);
+            videoElement.addEventListener('playing', this.showAirplayPickerBound);
+          }
         }
       }
 

--- a/js/controller.js
+++ b/js/controller.js
@@ -501,8 +501,12 @@ module.exports = function(OO, _, $, W) {
       if (!this.state.airPlayStatusIcon) {
         const airPlayState = window.sessionStorage.getItem('airPlayState');
         if (airPlayState === CONSTANTS.AIRPLAY_STATE.CONNECTED) {
-          this.showControlBar();
-          this.state.mainVideoElement.webkitShowPlaybackTargetPicker();
+          const onVideoPlaying = () => {
+            this.showControlBar();
+            this.state.mainVideoElement.webkitShowPlaybackTargetPicker();
+            this.state.mainVideoElement.removeEventListener('playing', onVideoPlaying);
+          };
+          this.state.mainVideoElement.addEventListener('playing', onVideoPlaying);
         }
         this.state.airPlayStatusIcon = CONSTANTS.AIRPLAY_STATE.DISCONNECTED;
         this.renderSkin();

--- a/js/controller.js
+++ b/js/controller.js
@@ -493,6 +493,11 @@ module.exports = function(OO, _, $, W) {
     },
 
     showAirplayPicker: function() {
+      const airPlayState = window.sessionStorage.getItem('airPlayState');
+      if (airPlayState !== CONSTANTS.AIRPLAY_STATE.CONNECTED) {
+        this.state.mainVideoElement.removeEventListener('playing', this.showAirplayPickerBound);
+        return;
+      }
       this.showControlBar();
       this.state.mainVideoElement.webkitShowPlaybackTargetPicker();
       this.state.mainVideoElement.removeEventListener('playing', this.showAirplayPickerBound);
@@ -604,11 +609,8 @@ module.exports = function(OO, _, $, W) {
           videoElement.addEventListener('webkitcurrentplaybacktargetiswirelesschanged',
             _.bind(this.toggleAirPlayIcon, this));
 
-          const airPlayState = window.sessionStorage.getItem('airPlayState');
-          if (airPlayState === CONSTANTS.AIRPLAY_STATE.CONNECTED) {
-            this.showAirplayPickerBound = this.showAirplayPicker.bind(this);
-            videoElement.addEventListener('playing', this.showAirplayPickerBound);
-          }
+          this.showAirplayPickerBound = this.showAirplayPicker.bind(this);
+          videoElement.addEventListener('playing', this.showAirplayPickerBound);
         }
       }
 


### PR DESCRIPTION
https://jira.corp.ooyala.com/browse/PLAYER-5095