### PR TITLE
[bugfix/PLAYER-5164] Audio-Only player control alignment issue

### DIFF
--- a/scss/components/_discovery-panel.scss
+++ b/scss/components/_discovery-panel.scss
@@ -34,11 +34,11 @@
 }
 
 .oo-discovery-image-wrapper-style {
+  @include flex-shrink(0);
   position: relative;
   width: 150px;
   height: auto;
   margin: 0 42px 42px 0;
-  flex-shrink: 0;
 
   &:nth-of-type(even) {
     margin-bottom: 0;

--- a/scss/components/_state-screen.scss
+++ b/scss/components/_state-screen.scss
@@ -25,16 +25,19 @@
     position: relative;
   }
 
+  $timeMinWidth: 35px;
   .oo-scrubber-bar-right {
+    @include flex-shrink(0);
     margin-left: 8px;
     text-align: right;
     padding-right: 0px !important;
-    width: 35px;
+    min-width: $timeMinWidth;
   }
 
   .oo-scrubber-bar-left {
+    @include flex-shrink(0);
     margin-right: 8px;
-    width: 35px;
+    min-width: $timeMinWidth;
   }
 
   .oo-state-screen-audio-title {

--- a/scss/mixins/_mixins.scss
+++ b/scss/mixins/_mixins.scss
@@ -266,6 +266,14 @@
   flex: $values;
 }
 
+// Flex shrink {Number}: applies to flex item shrink factor
+@mixin flex-shrink($shrink) {
+  -webkit-flex-shrink: $shrink;
+  -moz-flex-shrink: $shrink;
+  -ms-flex-shrink: $shrink;
+  flex-shrink: $shrink;
+}
+
 @mixin flex-center-children($flex-direction) {
   @include flexbox;
   @include flex-direction($flex-direction);


### PR DESCRIPTION
35px is not enough for a timer , when the timer includes hh:mm:ss,
"Width" was change to "min-width" and "flex-shrink" was added to prevent the possibility of compressing the element