### PR TITLE
[fix/PLAYER-5204] Add page-level parameter to disable AirPlay option

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -630,17 +630,28 @@ function controller(OO, _, $) {
       if (videoElement) {
         videoElement.addEventListener('loadedmetadata', this.metaDataLoaded.bind(this));
 
-        // add the AirPlay TargetAvailability event listener
-        if (window.WebKitPlaybackTargetAvailabilityEvent && this.state.isAirplayAllowed) {
-          videoElement.addEventListener('webkitplaybacktargetavailabilitychanged',
-            _.bind(this.airPlayListener, this));
+        // add the AirPlay event listeners
+        if (window.WebKitPlaybackTargetAvailabilityEvent) {
+          const airPlayState = window.sessionStorage.getItem('airPlayState');
+          if (airPlayState === CONSTANTS.AIRPLAY_STATE.CONNECTED || this.state.isAirplayAllowed) {
+            videoElement.addEventListener(
+              'webkitplaybacktargetavailabilitychanged',
+              _.bind(this.airPlayListener, this)
+            );
 
-          // This event fires when a media element starts or stops AirPlay playback
-          videoElement.addEventListener('webkitcurrentplaybacktargetiswirelesschanged',
-            _.bind(this.toggleAirPlayIcon, this));
+            // This event fires when a media element starts or stops AirPlay playback
+            videoElement.addEventListener(
+              'webkitcurrentplaybacktargetiswirelesschanged',
+              _.bind(this.toggleAirPlayIcon, this)
+            );
 
-          this.showAirplayPickerBound = this.showAirplayPicker.bind(this);
-          videoElement.addEventListener('playing', this.showAirplayPickerBound);
+            // Showing the AirPlay target picker if it was connected before reloading
+            this.showAirplayPickerBound = this.showAirplayPicker.bind(this);
+            videoElement.addEventListener(
+              'playing',
+              this.showAirplayPickerBound
+            );
+          }
         }
       }
 

--- a/js/controller.js
+++ b/js/controller.js
@@ -554,7 +554,10 @@ function controller(OO, _, $) {
       } else {
         if (this.airPlayWasConnected) {
           const videoElement = this.state.mainVideoElement;
-          videoElement.webkitShowPlaybackTargetPicker();
+          // We need timeout to display the target picker checkbox correctly in MacOS
+          setTimeout(() => {
+            videoElement.webkitShowPlaybackTargetPicker();
+          });
           this.airPlayWasConnected = false;
         }
         this.state.airPlayStatusIcon = this.state.airPlayStatusIcon === CONSTANTS.AIRPLAY_STATE.DISCONNECTED

--- a/js/controller.js
+++ b/js/controller.js
@@ -524,21 +524,22 @@ function controller(OO, _, $) {
     },
 
     addAirPlayListeners(videoElement) {
-      if (window.WebKitPlaybackTargetAvailabilityEvent) {
-        const airPlayState = window.sessionStorage.getItem('airPlayState');
-        this.airPlayWasConnected = airPlayState === CONSTANTS.AIRPLAY_STATE.CONNECTED;
-        if (this.airPlayWasConnected || this.state.isAirplayAllowed) {
-          videoElement.addEventListener(
-            'webkitplaybacktargetavailabilitychanged',
-            _.bind(this.airPlayListener, this)
-          );
+      if (!window.WebKitPlaybackTargetAvailabilityEvent) {
+        return;
+      }
+      const airPlayState = window.sessionStorage.getItem('airPlayState');
+      this.airPlayWasConnected = airPlayState === CONSTANTS.AIRPLAY_STATE.CONNECTED;
+      if (this.airPlayWasConnected || this.state.isAirplayAllowed) {
+        videoElement.addEventListener(
+          'webkitplaybacktargetavailabilitychanged',
+          _.bind(this.airPlayListener, this)
+        );
 
-          // This event fires when a media element starts or stops AirPlay playback
-          videoElement.addEventListener(
-            'webkitcurrentplaybacktargetiswirelesschanged',
-            _.bind(this.toggleAirPlayIcon, this)
-          );
-        }
+        // This event fires when a media element starts or stops AirPlay playback
+        videoElement.addEventListener(
+          'webkitcurrentplaybacktargetiswirelesschanged',
+          _.bind(this.toggleAirPlayIcon, this)
+        );
       }
     },
 
@@ -551,21 +552,21 @@ function controller(OO, _, $) {
       if (!this.state.airPlayStatusIcon) {
         this.state.airPlayStatusIcon = CONSTANTS.AIRPLAY_STATE.DISCONNECTED;
         this.renderSkin();
-      } else {
-        if (this.airPlayWasConnected) {
-          const videoElement = this.state.mainVideoElement;
-          // We need timeout to display the target picker checkbox correctly in MacOS
-          setTimeout(() => {
-            videoElement.webkitShowPlaybackTargetPicker();
-          });
-          this.airPlayWasConnected = false;
-        }
-        this.state.airPlayStatusIcon = this.state.airPlayStatusIcon === CONSTANTS.AIRPLAY_STATE.DISCONNECTED
-          ? CONSTANTS.AIRPLAY_STATE.CONNECTED
-          : CONSTANTS.AIRPLAY_STATE.DISCONNECTED;
-        window.sessionStorage.setItem('airPlayState', this.state.airPlayStatusIcon);
-        this.renderSkin();
+        return;
       }
+      if (this.airPlayWasConnected) {
+        const videoElement = this.state.mainVideoElement;
+        // We need timeout to display the target picker checkbox correctly in MacOS
+        setTimeout(() => {
+          videoElement.webkitShowPlaybackTargetPicker();
+        });
+        this.airPlayWasConnected = false;
+      }
+      this.state.airPlayStatusIcon = this.state.airPlayStatusIcon === CONSTANTS.AIRPLAY_STATE.DISCONNECTED
+        ? CONSTANTS.AIRPLAY_STATE.CONNECTED
+        : CONSTANTS.AIRPLAY_STATE.DISCONNECTED;
+      window.sessionStorage.setItem('airPlayState', this.state.airPlayStatusIcon);
+      this.renderSkin();
     },
 
     /**


### PR DESCRIPTION
https://jira.corp.ooyala.com/browse/PLAYER-5204

case 1: 
load an asset with airplay enabled
try loading another asset in the same window with airplay set as false
airplay continues with the existing session
but in this case, the user would not be able to opt out of airplay (since the icon would no longer be visible).