### PR TITLE
[PLAYER-5216] Show console warning when cast enabled but blocked

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -504,6 +504,10 @@ function controller(OO, _, $) {
     },
 
     isChromecastEnabled(params) {
+      if (!OO.isSSL) {
+        console.warn('Casting is enabled but impossible for http hosted pages. Serve the page through https for casting');
+        return false;
+      }
       const chromecastConfig = params.chromecast;
       const appId = Utils.getPropertyValue(chromecastConfig, 'appId', '');
       return typeof appId === 'string'

--- a/js/controller.js
+++ b/js/controller.js
@@ -504,15 +504,17 @@ function controller(OO, _, $) {
     },
 
     isChromecastEnabled(params) {
-      if (!OO.isSSL) {
+      const chromecastConfig = params.chromecast;
+      const chromecastEnabled = !!Utils.getPropertyValue(chromecastConfig, 'enable', false);
+      const appId = Utils.getPropertyValue(chromecastConfig, 'appId', '');
+      const appIdValid = typeof appId === 'string' && appId !== '';
+      
+      if (chromecastEnabled && !OO.isSSL) {
         console.warn('Casting is enabled but impossible for http hosted pages. Serve the page through https for casting');
         return false;
       }
-      const chromecastConfig = params.chromecast;
-      const appId = Utils.getPropertyValue(chromecastConfig, 'appId', '');
-      return typeof appId === 'string'
-        && appId !== ''
-        && !!Utils.getPropertyValue(chromecastConfig, 'enable', false);
+
+      return appIdValid && chromecastEnabled;
     },
 
     onChromecastStartCast(event, deviceName) {

--- a/js/controller.js
+++ b/js/controller.js
@@ -508,12 +508,12 @@ function controller(OO, _, $) {
       const chromecastEnabled = !!Utils.getPropertyValue(chromecastConfig, 'enable', false);
       const appId = Utils.getPropertyValue(chromecastConfig, 'appId', '');
       const appIdValid = typeof appId === 'string' && appId !== '';
-      
       if (chromecastEnabled && !OO.isSSL) {
-        console.warn('Casting is enabled but impossible for http hosted pages. Serve the page through https for casting');
+        // eslint-disable-next-line no-console
+        console.warn('Casting is enabled but impossible for http hosted pages.'
+        + 'Serve the page through https for casting');
         return false;
       }
-
       return appIdValid && chromecastEnabled;
     },
 

--- a/tests/html5skin-test.js
+++ b/tests/html5skin-test.js
@@ -1745,6 +1745,7 @@ describe('Controller', function() {
 
   describe('Chromecast button', () => {
     it('Should enable the chromecast button at state when appId is valid and enable it is true', () => {
+      OO.isSSL = true;
       controller.loadConfigData({
         chromecast: {
           enable: true,


### PR DESCRIPTION
Should I add additional check to the core.js? (in ChromecastSender.js)
to not load this module completely
```
if (OO.isChrome && OO.isSSL && !OO.isIos) {
}
```
or this check is sufficient? (just in Html5Skin)