### PR TITLE
[bugfix/PLAYER-5272] loading spinner is displayed on IMA ads

### DIFF
--- a/js/constants/constants.js
+++ b/js/constants/constants.js
@@ -302,6 +302,10 @@ const CONSTANTS = {
     END: 'End',
   },
 
+  ENCODINGS: {
+    IMA: 'ima',
+  },
+
   UI: {
     defaultScrubberBarHeight: 4,
     POPOVER_SCROLL_RATE: 0.6,

--- a/js/controller.js
+++ b/js/controller.js
@@ -32,7 +32,7 @@ function controller(OO, _, $) {
   const UNSUPPORTED_PLAYER_VERSION = 3;
 
   if (!OO.playerParams.core_version || OO.playerParams.core_version <= UNSUPPORTED_PLAYER_VERSION) {
-    console.error('Html5Skin requires at least player version 4.'); // eslint-disable-line
+    console.error('Html5Skin requires at least player version 4.');
     return null;
   }
 

--- a/js/controller.js
+++ b/js/controller.js
@@ -32,7 +32,7 @@ function controller(OO, _, $) {
   const UNSUPPORTED_PLAYER_VERSION = 3;
 
   if (!OO.playerParams.core_version || OO.playerParams.core_version <= UNSUPPORTED_PLAYER_VERSION) {
-    console.error('Html5Skin requires at least player version 4.');
+    console.error('Html5Skin requires at least player version 4.'); // eslint-disable-line
     return null;
   }
 
@@ -60,6 +60,7 @@ function controller(OO, _, $) {
     this.toggleButtons = {};
     this.handleVrMobileOrientation = this.handleVrMobileOrientation.bind(this);
     this.languageList = [];
+    this.selectedEncoding = '';
     this.state = {
       playerParam: {},
       skinMetaData: {},
@@ -1052,7 +1053,8 @@ function controller(OO, _, $) {
       }
     },
 
-    onPlaying(event, source) {
+    onPlaying(event, source, selectedEncoding) {
+      this.selectedEncoding = selectedEncoding;
       if (source === OO.VIDEO.MAIN) {
         // set mainVideoElement if not set during video plugin initialization
         if (!this.state.mainVideoMediaType) {

--- a/js/views/adScreen.jsx
+++ b/js/views/adScreen.jsx
@@ -205,36 +205,46 @@ class AdScreen extends React.Component {
   };
 
   render() {
+    const {
+      controller,
+      skinConfig,
+      playerState,
+      buffered,
+    } = this.props;
     const actionIconStyle = {
-      color: this.props.skinConfig.pauseScreen.PauseIconStyle.color,
-      opacity: this.props.skinConfig.pauseScreen.PauseIconStyle.opacity,
+      color: skinConfig.pauseScreen.PauseIconStyle.color,
+      opacity: skinConfig.pauseScreen.PauseIconStyle.opacity,
     };
     const actionIconClass = ClassNames({
-      'oo-action-icon-pause': !this.props.controller.state.adPauseAnimationDisabled,
-      'oo-action-icon': this.props.controller.state.adPauseAnimationDisabled,
-      'oo-animate-pause': !this.props.controller.state.adPauseAnimationDisabled,
+      'oo-action-icon-pause': !controller.state.adPauseAnimationDisabled,
+      'oo-action-icon': controller.state.adPauseAnimationDisabled,
+      'oo-animate-pause': !controller.state.adPauseAnimationDisabled,
       'oo-action-icon-top':
-        this.props.skinConfig.pauseScreen.pauseIconPosition.toLowerCase().indexOf('top') > -1,
+        skinConfig.pauseScreen.pauseIconPosition.toLowerCase().indexOf('top') > -1,
       'oo-action-icon-bottom':
-        this.props.skinConfig.pauseScreen.pauseIconPosition.toLowerCase().indexOf('bottom') > -1,
+        skinConfig.pauseScreen.pauseIconPosition.toLowerCase().indexOf('bottom') > -1,
       'oo-action-icon-left':
-        this.props.skinConfig.pauseScreen.pauseIconPosition.toLowerCase().indexOf('left') > -1,
+        skinConfig.pauseScreen.pauseIconPosition.toLowerCase().indexOf('left') > -1,
       'oo-action-icon-right':
-        this.props.skinConfig.pauseScreen.pauseIconPosition.toLowerCase().indexOf('right') > -1,
-      'oo-hidden': !this.props.skinConfig.pauseScreen.showPauseIcon,
-      'oo-icon-hidden': this.props.playerState !== CONSTANTS.STATE.PAUSE,
+        skinConfig.pauseScreen.pauseIconPosition.toLowerCase().indexOf('right') > -1,
+      'oo-hidden': !skinConfig.pauseScreen.showPauseIcon,
+      'oo-icon-hidden': playerState !== CONSTANTS.STATE.PAUSE,
     });
     let adPanel = null;
-    if (this.props.skinConfig.adScreen.showAdMarquee && this.props.controller.state.showAdMarquee) {
+    if (skinConfig.adScreen.showAdMarquee && controller.state.showAdMarquee) {
       adPanel = <AdPanel {...this.props} />;
     }
     let playbackControlItems = null;
-    if (this.props.skinConfig.adScreen.showControlBar) {
+    if (skinConfig.adScreen.showControlBar) {
       playbackControlItems = this.getPlaybackControlItems();
     }
 
-    const showUnmute = this.props.controller.state.volumeState.mutingForAutoplay
-      && this.props.controller.state.volumeState.muted;
+    const showUnmute = controller.state.volumeState.mutingForAutoplay
+      && controller.state.volumeState.muted;
+
+    const isIMA = controller.selectedEncoding === CONSTANTS.ENCODINGS.IMA;
+    const isShowSpinner = this.props.controller.state.buffering
+      || (!isIMA && buffered === 0); // buffered for IMA is always 0, so we can not use the property
 
     return (
       <div // eslint-disable-line jsx-a11y/mouse-events-have-key-events
@@ -247,8 +257,8 @@ class AdScreen extends React.Component {
         onMouseUp={this.handleClick}
       >
         {
-          this.props.controller.state.buffering || this.props.buffered === 0
-            ? <Spinner loadingImage={this.props.skinConfig.general.loadingImage.imageResource.url} />
+          isShowSpinner
+            ? <Spinner loadingImage={skinConfig.general.loadingImage.imageResource.url} />
             : null
         }
 

--- a/tests/views/adScreen-test.js
+++ b/tests/views/adScreen-test.js
@@ -8,7 +8,6 @@ var Enzyme = require('enzyme');
 var AdScreen = require('../../js/views/adScreen');
 var defaultSkinConfig = require('../../config/skin.json');
 var UnmuteIcon = require('../../js/components/unmuteIcon');
-var AdPanel = require('../../js/components/adPanel');
 const Spinner = require('../../js/components/spinner');
 
 describe('AdScreen', () => {
@@ -241,25 +240,33 @@ describe('AdScreen', () => {
       );
     };
 
-    it('Spinner should not be shown when buffering is false and buffered !== 0', function(){
-      let wrapper = createAdScreen(2, false);
+    it('Spinner should not be shown when buffering is false and buffered !== 0', () => {
+      const wrapper = createAdScreen(2, false);
       expect(wrapper.find(Spinner).length).toBe(0);
     });
 
-    it('Spinner should not be shown when buffering is false and buffered === null', function(){
-      let wrapper = createAdScreen(null, false);
+    it('Spinner should not be shown when buffering is false and buffered === null', () => {
+      const wrapper = createAdScreen(null, false);
       expect(wrapper.find(Spinner).length).toBe(0);
     });
 
-    it('Spinner should be shown when buffered === 0', function(){
-      let wrapper = createAdScreen(0, false);
+    it('Spinner should be shown when buffered === 0', () => {
+      const wrapper = createAdScreen(0, false);
       expect(wrapper.find(Spinner).length).toBe(1);
     });
 
-    it('Spinner should be shown when buffering is true even if buffered !== 0', function(){
-      let wrapper = createAdScreen(2, true);
+    it('Spinner should be shown when buffering is true even if buffered !== 0', () => {
+      const wrapper = createAdScreen(2, true);
       expect(wrapper.find(Spinner).length).toBe(1);
     });
+
+    it('Spinner should be shown when buffered === 0 but selectedEncoding is ima', () => {
+      mockController.selectedEncoding = 'ima';
+      const wrapper = createAdScreen(0, false);
+      expect(wrapper.find(Spinner).length).toBe(0);
+      mockController.selectedEncoding = '';
+    });
+
   });
 
   it('should not display unmute icon when not muted', () => {


### PR DESCRIPTION
We show a spinner if prop "buffering" is true or prop "buffered" is 0, but we can not check changes of the value of "buffered" for "ima" video (the value is 0 all time). So we check if the video is ima, and if it is, do not use this rule.

[Connected PR](https://git.corp.ooyala.com/projects/PBW/repos/mjolnir/pull-requests/650)

Unit tests passed.
