### PR TITLE
[PLAYER-254] Autohide cursor in full-screen mode when the control bar also auto-hides

### DIFF
--- a/js/views/playingScreen.jsx
+++ b/js/views/playingScreen.jsx
@@ -360,6 +360,8 @@ class PlayingScreen extends React.Component {
     );
     const className = ClassNames('oo-state-screen oo-playing-screen', {
       'oo-controls-active': skipControlsEnabled && this.props.controller.state.controlBarVisible,
+      'oo-hide-cursor': !this.props.controller.state.controlBarVisible
+        && this.props.controller.state.fullscreen,
     });
 
     // Always show the poster image on cast session

--- a/scss/components/_playing-screen.scss
+++ b/scss/components/_playing-screen.scss
@@ -9,4 +9,8 @@
   .oo-text-track-container.oo-in-background {
     z-index: $zindex-background-captions;
   }
+
+  &.oo-hide-cursor *{
+    cursor: none !important;
+  }
 }


### PR DESCRIPTION
Hide the cursor when the control bar get hidden on fullscreen mode