### PR TITLE
[PLAYER-5383] Cannot read property updatePlayhead

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -829,7 +829,9 @@ function controller(OO, _, $) {
       this.state.contentTree = contentTree;
       this.state.playerState = CONSTANTS.STATE.START;
       // Make sure playhead is reset when we switch to a new video
-      this.skin.updatePlayhead(0, contentTree.duration, 0, 0);
+      if (this.skin) {
+        this.skin.updatePlayhead(0, contentTree.duration, 0, 0);
+      }
     },
 
     onAssetUpdated(event, asset) {


### PR DESCRIPTION
[Jira Link](https://jira.corp.ooyala.com/browse/PLAYER-5383)

when player is created
```javascript
OO.Player.create("ooplayer", asset, playerparam);
```
core.js publishes **PLAYER_CREATED** event and then defers **ASSET_CHANGED** event
```javascript
mb.publish(OO.EVENTS.PLAYER_CREATED);
...
_.defer(() => {
   this.mb.publish(OO.EVENTS.ASSET_CHANGED, asset, params);
}); // === setTimeout(cb, 0)
```
PLAYER_CREATED -> stack is empty -> ASSET_CHANGED

-------------
in Skin.js on **PLAYER_CREATED** event **this.skin** is assigned _asynchronously_ if there's a skin config link in the params
```javascript
mb.subscribe(OO.EVENTS.PLAYER_CREATED, (params) => {
  if (params.skin.config) {
      $.getJSON( params.skin.config, () => this.skin = ReactDom.render());
  }
})
```

so when deferred **ASSET_CHANGED** event is fired this.skin could be not assigned yet
```javascript
onAssetChanged() {
  this.skin.updatePlayhead(); // Cannot read property 'updatePlayhead' of undefined
}
```

PLAYER_CREATED - $.getJSON(url, **cb**) -> stack is empty -> ASSET_CHANGED - this.skin is _undefined_ -> stack is empty -> **cb**