### PR TITLE
[PLAYER-5104] [v4] [airplay] video doesnt play on turning off airplay using native (IOS) airplay option

### DIFF
--- a/js/components/controlBar.jsx
+++ b/js/components/controlBar.jsx
@@ -957,7 +957,7 @@ class ControlBar extends React.Component {
         )
         && (
           item.name !== 'airPlay'
-          || (controller.state.airplay && controller.state.airplay.available)
+          || (controller.state.airplay && controller.state.airplay.available && !Utils.isIPhone())
         );
     });
 

--- a/tests/components/controlBar-test.js
+++ b/tests/components/controlBar-test.js
@@ -1372,6 +1372,17 @@ describe('ControlBar', function() {
       const wrapper = Enzyme.mount(getControlBar());
       const airPlayBtn = wrapper.find('.oo-airplay').hostNodes();
       expect(airPlayBtn.length).toBe(0);
+    });
+
+    it('Should not display the AirPlay button on Iphones', () => {
+      OO_setWindowNavigatorProperty('userAgent', 'phone');
+      OO_setWindowNavigatorProperty('platform', 'iPhone');
+      baseMockController.state.airplay.available = true;
+      const wrapper = Enzyme.mount(getControlBar());
+      const airPlayBtn = wrapper.find('.oo-airplay').hostNodes();
+      expect(airPlayBtn.length).toBe(0);
+      OO_setWindowNavigatorProperty('userAgent', 'desktop');
+      OO_setWindowNavigatorProperty('platform', '');
     })
   })
 });


### PR DESCRIPTION
I have removed the airplay button for Iphones because the IOS native AirPlay control button in the full-screen mode can not fully synchronize with our AirPlay button.