### PR TITLE
[PLAYER-5404] web IE videos do not play on fullscreen

### DIFF
--- a/scss/skin/_default.scss
+++ b/scss/skin/_default.scss
@@ -49,8 +49,8 @@
     overflow: hidden;
     top:0;
     left:0;
-    width:100%;
-    height:100%;
+    width:100% !important;
+    height:100% !important;
   }
 }
 


### PR DESCRIPTION
That css `.oo-fullscreen` width and height were being overwritten.

https://jira.corp.ooyala.com/browse/PLAYER-5404