### PR TITLE
[PBW-7924] skin doesn't re-render in the end if not hovered, fixed …

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -1203,6 +1203,7 @@ function controller(OO, _, $) {
         OO.log('Should display DISCOVERY_SCREEN on end');
         this.sendDiscoveryDisplayEventRelatedVideos('endScreen');
         this.state.screenToShow = CONSTANTS.SCREEN.DISCOVERY_SCREEN;
+        this.renderSkin();
       } else if (this.skin.props.skinConfig.endScreen.screenToShowOnEnd === 'share') {
         this.state.screenToShow = CONSTANTS.SCREEN.SHARE_SCREEN;
       } else {


### PR DESCRIPTION
When playback ends, skin doesn't render discovery screen just because not forced to do this. It passed through QA because when hovered any tiny mouse move triggers re-render. But TS reported the issue when the player is not hovered. Fixed this.