### PR TITLE
[PLAYER-5512] fix seeking on live streams

### DIFF
--- a/js/components/scrubberBar.jsx
+++ b/js/components/scrubberBar.jsx
@@ -210,7 +210,6 @@ class ScrubberBar extends React.Component {
     controller.seek(currentPlayhead);
     if (this._isMounted) { // eslint-disable-line
       this.setState({ currentPlayhead, scrubbingPlayheadX: 0 }); // eslint-disable-line
-      controller.endSeeking();
     }
     this.touchInitiated = false;
   }


### PR DESCRIPTION
`endSeeking` sets `seeking` property to `false`. It happens right after the seeking was started and causes flickering of the playhead.
corresponding pr to bitwrapper: https://git.corp.ooyala.com/projects/PBW/repos/video-plugins-internal/pull-requests/411/overview