### PR TITLE
[PLAYER-5283] Respect Backlot flag for "Show image above player" flag for Audio Only Player

### DIFF
--- a/js/controller.js
+++ b/js/controller.js
@@ -773,7 +773,9 @@ function controller(OO, _, $) {
         this.skin.updatePlayhead(null, duration)
           .catch(() => { OO.log('onContentTreeFetched: Could not set new state for skin'); });
       }
-      if (this.state.audioOnly && contentTree.promo_image) {
+      const shouldRenderCoverImage = this.state.audioOnly && contentTree.promo_image
+        && this.state.config.audio.displayTitleOnVideoCanvas;
+      if (shouldRenderCoverImage) {
         this.state.mainVideoContainer.height(CONSTANTS.UI.AUDIO_ONLY_WITH_COVER_HEIGHT);
       }
     },

--- a/js/views/audioOnlyScreen.jsx
+++ b/js/views/audioOnlyScreen.jsx
@@ -117,10 +117,13 @@ class AudioOnlyScreen extends React.Component {
     const coverImageHeight = `${CONSTANTS.UI.AUDIO_ONLY_WITH_COVER_HEIGHT.slice(0, shift)
       - CONSTANTS.UI.AUDIO_ONLY_DEFAULT_HEIGHT.slice(0, shift)}px`;
 
+    const shouldRenderCoverImage = this.props.contentTree.promo_image
+      && this.props.skinConfig.audio.displayTitleOnVideoCanvas;
+
     // TODO: Consider multiple styling options for the control bar. We are restricted to a single row at this moment
     return (
       <div>
-        {this.props.contentTree.promo_image
+        {shouldRenderCoverImage
           && (
             <img
               height={coverImageHeight}

--- a/tests/views/audioOnlyScreen-test.js
+++ b/tests/views/audioOnlyScreen-test.js
@@ -178,4 +178,15 @@ describe('Audio Only Screen', () => {
     expect(dvrText.innerHTML).toBe("-15:00")
   });
 
+  it('renders audio only screen with cover Image', () => {
+    mockContentTree.promo_image = 'url';
+    mockSkinConfig.audio.displayTitleOnVideoCanvas = true;
+    let wrapper = renderAudioOnlyScreen();
+    expect(wrapper.find('.oo-audio-only-coverImg').length).toBe(1);
+
+    mockSkinConfig.audio.displayTitleOnVideoCanvas = false;
+    wrapper = renderAudioOnlyScreen();
+    expect(wrapper.find('.oo-audio-only-coverImg').length).toBe(0);
+  })
+
 });


### PR DESCRIPTION
https://jira.corp.ooyala.com/browse/PLAYER-5283

There is a new param in skin config - "displayTitleOnVideoCanvas". It is currently available on staging.

 [The debug link](http://debug.ooyala.com/ea/index.html?ec=JmNHcwaDE6dJZ3gIB9dSsqo_3GvrXv3D&pbid=12a647f6b8ae4cb5a097eec8ec779b43&pcode=c0cTkxOqALQviQIGAHWY5hP0q9gU&core_player=%2F%2Fplayer-staging.ooyala.com%2Fcore%2F12a647f6b8ae4cb5a097eec8ec779b43&video_plugins=.&trackingLevel=unset)

