### PR TITLE
Revert "[PBW-7817] Added roles for screen reader NVDA"

### DIFF
--- a/js/components/controlBar.jsx
+++ b/js/components/controlBar.jsx
@@ -483,7 +483,6 @@ class ControlBar extends React.Component {
           icon={playIcon}
           tooltip={playButtonTooltip}
           onClick={this.handlePlayClick}
-          role="radio"
         />
       ),
 
@@ -509,7 +508,6 @@ class ControlBar extends React.Component {
             icon={volumeIcon}
             tooltip={mutedInUi ? CONSTANTS.SKIN_TEXT.UNMUTE : CONSTANTS.SKIN_TEXT.MUTE}
             onClick={this.handleVolumeIconClick}
-            role="radio"
           />
           {!hideVolumeControls && <VolumeControls {...this.props} />}
         </div>


### PR DESCRIPTION
Reverts ooyala/html5-skin#1257

We need to revert this in order to fix PBW-8050, this is because the screen readers are identifying play and mute icons as radio button.
For now Windows7+IE11 + NVDA are working fine and the issue remains only for Windows7+Firefox + NVDA