### PR TITLE
fix/PLAYER-5104 hide fullscreen button for on Ios when AirPlay available

### DIFF
--- a/js/components/controlBar.jsx
+++ b/js/components/controlBar.jsx
@@ -923,7 +923,10 @@ class ControlBar extends React.Component {
         )
         && (
           item.name !== 'airPlay'
-          || (controller.state.airplay && controller.state.airplay.available && !Utils.isIPhone())
+          || (
+            controller.state.airplay
+            && controller.state.airplay.available
+            && !Utils.isIos())
         );
     });
 


### PR DESCRIPTION
Previous investigation from Aleksander Afanasev:
«I have checked this on Iphone X and looks like IOS native AirPlay control button in the full-screen mode can not fully synchronize with our AirPlay button. So, in order to resolve this issue I suggest to remove our AirPlay button from control bar for Iphones. As for IPAD, it can render our control bar in full-screen mode and it doesn't have the native controls, so it works fine.»
Since QA reports the issue remains for IPAD, I expand original solution to all IOS based devices: IPhone, IPad when AirPlay is available.